### PR TITLE
Implement structured lexer nodes

### DIFF
--- a/include/structure/graphics/lumina/compiler/spk_ast.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_ast.hpp
@@ -11,12 +11,23 @@
 
 namespace spk::Lumina
 {
-	struct ASTNode
-	{
-		enum class Kind
-		{
-			
-		};
+        struct ASTNode
+        {
+                enum class Kind
+                {
+                        Token,
+                        Compound,
+                        Namespace,
+                        Structure,
+                        AttributeBlock,
+                        ConstantBlock,
+                       Texture,
+                       Include,
+                       Function,
+                        Method,
+                        PipelineDefinition,
+                        PipelineBody
+                };
 
 		Location location;
 		Kind kind;
@@ -28,6 +39,169 @@ namespace spk::Lumina
 		}
 		virtual ~ASTNode() = default;
 
-		virtual void print(std::wostream& p_os, size_t p_indent = 0) const = 0;
-	};
+                virtual void print(std::wostream& p_os, size_t p_indent = 0) const = 0;
+        };
+
+       std::wstring to_wstring(ASTNode::Kind p_kind);
+       std::string to_string(ASTNode::Kind p_kind);
+
+       struct TokenNode : public ASTNode
+       {
+               Token token;
+
+               explicit TokenNode(const Token &p_token) :
+                       ASTNode(Kind::Token, p_token.location),
+                       token(p_token)
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct CompoundNode : public ASTNode
+       {
+               std::vector<std::unique_ptr<ASTNode>> children;
+
+               explicit CompoundNode(Location p_location) :
+                       ASTNode(Kind::Compound, std::move(p_location))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct NamespaceNode : public ASTNode
+       {
+               Token name;
+               std::unique_ptr<CompoundNode> body;
+
+               NamespaceNode(const Token &p_name, std::unique_ptr<CompoundNode> p_body) :
+                       ASTNode(Kind::Namespace, p_name.location),
+                       name(p_name),
+                       body(std::move(p_body))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct StructureNode : public ASTNode
+       {
+               Token name;
+               std::unique_ptr<CompoundNode> body;
+
+               StructureNode(const Token &p_name, std::unique_ptr<CompoundNode> p_body) :
+                       ASTNode(Kind::Structure, p_name.location),
+                       name(p_name),
+                       body(std::move(p_body))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct AttributeBlockNode : public ASTNode
+       {
+               Token name;
+               std::unique_ptr<CompoundNode> body;
+
+               AttributeBlockNode(const Token &p_name, std::unique_ptr<CompoundNode> p_body) :
+                       ASTNode(Kind::AttributeBlock, p_name.location),
+                       name(p_name),
+                       body(std::move(p_body))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct ConstantBlockNode : public ASTNode
+       {
+               Token name;
+               std::unique_ptr<CompoundNode> body;
+
+               ConstantBlockNode(const Token &p_name, std::unique_ptr<CompoundNode> p_body) :
+                       ASTNode(Kind::ConstantBlock, p_name.location),
+                       name(p_name),
+                       body(std::move(p_body))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct TextureNode : public ASTNode
+       {
+               Token name;
+
+               explicit TextureNode(const Token &p_name) :
+                       ASTNode(Kind::Texture, p_name.location),
+                       name(p_name)
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct FunctionNode : public ASTNode
+       {
+               std::vector<Token> header;
+               std::unique_ptr<CompoundNode> body;
+
+               FunctionNode(Kind p_kind, std::vector<Token> p_header, std::unique_ptr<CompoundNode> p_body) :
+                       ASTNode(p_kind, p_header.empty() ? Location{} : p_header.front().location),
+                       header(std::move(p_header)),
+                       body(std::move(p_body))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct PipelineDefinitionNode : public ASTNode
+       {
+               Token fromStage;
+               Token toStage;
+               std::vector<Token> declaration;
+
+               PipelineDefinitionNode(const Token &p_from, const Token &p_to, std::vector<Token> p_decl) :
+                       ASTNode(Kind::PipelineDefinition, p_from.location),
+                       fromStage(p_from),
+                       toStage(p_to),
+                       declaration(std::move(p_decl))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct PipelineBodyNode : public ASTNode
+       {
+               Token stage;
+               std::unique_ptr<CompoundNode> body;
+
+               PipelineBodyNode(const Token &p_stage, std::unique_ptr<CompoundNode> p_body) :
+                       ASTNode(Kind::PipelineBody, p_stage.location),
+                       stage(p_stage),
+                       body(std::move(p_body))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct IncludeNode : public ASTNode
+       {
+               std::vector<Token> path;
+               bool system;
+
+               IncludeNode(std::vector<Token> p_path, bool p_system, Location p_loc) :
+                       ASTNode(Kind::Include, std::move(p_loc)),
+                       path(std::move(p_path)),
+                       system(p_system)
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
 }

--- a/include/structure/graphics/lumina/compiler/spk_lexer.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_lexer.hpp
@@ -18,21 +18,33 @@ namespace spk::Lumina
 
 		std::vector<std::unique_ptr<ASTNode>> run();
 
-	private:
-		using ParseFn = std::unique_ptr<ASTNode> (Lexer::*)();
+        private:
+                using ParseFn = std::unique_ptr<ASTNode> (Lexer::*)();
 
-		void skipComment();
-		const Token &expect(Token::Type p_type);
-		const Token &expect(Token::Type p_type, const std::string &p_msg);
-		const Token &expect(const std::vector<Token::Type> &p_types);
-		const Token &expect(const std::vector<Token::Type> &p_types, const std::string &p_msg);
-		const Token &advance();
+                void skipComment();
+                std::unique_ptr<ASTNode> parseGeneric();
+                std::unique_ptr<ASTNode> parseCompound();
+                std::unique_ptr<ASTNode> parseNamespace();
+                std::unique_ptr<ASTNode> parseStruct();
+                std::unique_ptr<ASTNode> parseAttributeBlock();
+                std::unique_ptr<ASTNode> parseConstantBlock();
+               std::unique_ptr<ASTNode> parseTexture();
+               std::unique_ptr<ASTNode> parseInclude();
+               std::unique_ptr<ASTNode> parseShader();
+                std::unique_ptr<ASTNode> parseFunction(ASTNode::Kind p_kind);
+                bool isFunctionStart() const;
+                const Token &expect(Token::Type p_type);
+                const Token &expect(Token::Type p_type, const std::string &p_msg);
+                const Token &expect(const std::vector<Token::Type> &p_types);
+                const Token &expect(const std::vector<Token::Type> &p_types, const std::string &p_msg);
+                const Token &advance();
 		const Token &peek(std::ptrdiff_t p_offset = 0) const;
 		bool eof() const;
 
 		SourceManager &_sourceManager;
 		std::vector<Token> _tokens;
 		std::size_t _idx = 0;
-		std::unordered_map<Token::Type, ParseFn> _dispatch;
-	};
+                std::unordered_map<Token::Type, ParseFn> _dispatch;
+                bool _inStruct = false;
+        };
 }

--- a/src/structure/graphics/lumina/compiler/spk_ast.cpp
+++ b/src/structure/graphics/lumina/compiler/spk_ast.cpp
@@ -1,6 +1,150 @@
 #include "structure/graphics/lumina/compiler/spk_ast.hpp"
+#include "utils/spk_string_utils.hpp"
 
 namespace spk::Lumina
 {
-	
+       std::wstring to_wstring(ASTNode::Kind p_kind)
+       {
+               switch (p_kind)
+               {
+                       case ASTNode::Kind::Token:                return L"Token";
+                       case ASTNode::Kind::Compound:             return L"Compound";
+                       case ASTNode::Kind::Namespace:            return L"Namespace";
+                       case ASTNode::Kind::Structure:            return L"Structure";
+                       case ASTNode::Kind::AttributeBlock:       return L"AttributeBlock";
+                       case ASTNode::Kind::ConstantBlock:        return L"ConstantBlock";
+                       case ASTNode::Kind::Texture:              return L"Texture";
+                       case ASTNode::Kind::Include:              return L"Include";
+                       case ASTNode::Kind::Function:             return L"Function";
+                       case ASTNode::Kind::Method:               return L"Method";
+                       case ASTNode::Kind::PipelineDefinition:   return L"PipelineDefinition";
+                       case ASTNode::Kind::PipelineBody:         return L"PipelineBody";
+                       default:                                  return L"(Invalid)";
+               }
+       }
+
+       std::string to_string(ASTNode::Kind p_kind)
+       {
+               return spk::StringUtils::wstringToString(to_wstring(p_kind));
+       }
+       void TokenNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"Token("
+                       << to_wstring(token.type) << L", \"" << token.lexeme << L"\")\n";
+       }
+
+       void CompoundNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"Compound{" << std::endl;
+               for (const auto &child : children)
+               {
+                       if (child)
+                       {
+                               child->print(p_os, p_indent + 2);
+                       }
+               }
+               p_os << std::wstring(p_indent, L' ') << L"}" << std::endl;
+       }
+
+       void NamespaceNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"Namespace " << name.lexeme << L"{" << std::endl;
+               if (body)
+               {
+                       body->print(p_os, p_indent + 2);
+               }
+               p_os << std::wstring(p_indent, L' ') << L"}" << std::endl;
+       }
+
+       void StructureNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"Structure " << name.lexeme << L"{" << std::endl;
+               if (body)
+               {
+                       body->print(p_os, p_indent + 2);
+               }
+               p_os << std::wstring(p_indent, L' ') << L"}" << std::endl;
+       }
+
+       void AttributeBlockNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"AttributeBlock " << name.lexeme << L"{" << std::endl;
+               if (body)
+               {
+                       body->print(p_os, p_indent + 2);
+               }
+               p_os << std::wstring(p_indent, L' ') << L"}" << std::endl;
+       }
+
+       void ConstantBlockNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"ConstantBlock " << name.lexeme << L"{" << std::endl;
+               if (body)
+               {
+                       body->print(p_os, p_indent + 2);
+               }
+               p_os << std::wstring(p_indent, L' ') << L"}" << std::endl;
+       }
+
+       void TextureNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"Texture " << name.lexeme << L";" << std::endl;
+       }
+
+       void FunctionNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << to_wstring(kind);
+               for (const auto &tok : header)
+               {
+                       p_os << L" " << tok.lexeme;
+               }
+               if (body)
+               {
+                       p_os << L" {" << std::endl;
+                       body->print(p_os, p_indent + 2);
+                       p_os << std::wstring(p_indent, L' ') << L"}" << std::endl;
+               }
+               else
+               {
+                       p_os << L";" << std::endl;
+               }
+       }
+
+       void PipelineDefinitionNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"Pipeline " << fromStage.lexeme << L" -> " << toStage.lexeme << L":";
+               for (const auto &tok : declaration)
+               {
+                       p_os << L" " << tok.lexeme;
+               }
+               p_os << L";" << std::endl;
+       }
+
+       void PipelineBodyNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"PipelineStage " << stage.lexeme << L"(){" << std::endl;
+               if (body)
+               {
+                       body->print(p_os, p_indent + 2);
+               }
+               p_os << std::wstring(p_indent, L' ') << L"}" << std::endl;
+       }
+
+       void IncludeNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"Include ";
+               if (system)
+               {
+                       p_os << L"<";
+               }
+               for (const auto &tok : path)
+               {
+                       p_os << tok.lexeme;
+               }
+               if (system)
+               {
+                       p_os << L">";
+               }
+               p_os << std::endl;
+       }
 }

--- a/src/structure/graphics/lumina/compiler/spk_lexer.cpp
+++ b/src/structure/graphics/lumina/compiler/spk_lexer.cpp
@@ -7,14 +7,21 @@
 
 namespace spk::Lumina
 {
-	Lexer::Lexer(SourceManager &p_sourceManager, const std::vector<Token> &p_tokens) :
-		_sourceManager(p_sourceManager),
-		_tokens(p_tokens)
-	{
-		_dispatch = {
-
-		};
-	}
+        Lexer::Lexer(SourceManager &p_sourceManager, const std::vector<Token> &p_tokens) :
+                _sourceManager(p_sourceManager),
+                _tokens(p_tokens)
+        {
+                _dispatch = {
+                        {Token::Type::OpenCurlyBracket, &Lexer::parseCompound},
+                        {Token::Type::Namespace, &Lexer::parseNamespace},
+                        {Token::Type::Struct, &Lexer::parseStruct},
+                        {Token::Type::AttributeBlock, &Lexer::parseAttributeBlock},
+                        {Token::Type::ConstantBlock, &Lexer::parseConstantBlock},
+                        {Token::Type::Texture, &Lexer::parseTexture},
+                        {Token::Type::Preprocessor, &Lexer::parseInclude},
+                        {Token::Type::ShaderPass, &Lexer::parseShader}
+                };
+        }
 
 	const Token &Lexer::peek(std::ptrdiff_t p_offset) const
 	{
@@ -44,13 +51,190 @@ namespace spk::Lumina
 		return peek(-1);
 	}
 
-	void Lexer::skipComment()
-	{
-		while (peek().type == Token::Type::Comment || peek().type == Token::Type::Whitespace)
-		{
-			advance();
-		}
-	}
+       void Lexer::skipComment()
+       {
+               while (peek().type == Token::Type::Comment || peek().type == Token::Type::Whitespace)
+               {
+                       advance();
+               }
+       }
+
+       bool Lexer::isFunctionStart() const
+       {
+               return peek().type == Token::Type::Identifier &&
+                      peek(1).type == Token::Type::Identifier &&
+                      peek(2).type == Token::Type::OpenParenthesis;
+       }
+
+       std::unique_ptr<ASTNode> Lexer::parseFunction(ASTNode::Kind p_kind)
+       {
+               std::vector<Token> header;
+               while (!eof())
+               {
+                       if (peek().type == Token::Type::OpenCurlyBracket || peek().type == Token::Type::Semicolon)
+                       {
+                               break;
+                       }
+                       header.emplace_back(advance());
+               }
+
+               std::unique_ptr<CompoundNode> body;
+               if (peek().type == Token::Type::OpenCurlyBracket)
+               {
+                       auto compound = parseCompound();
+                       body.reset(static_cast<CompoundNode*>(compound.release()));
+               }
+
+               if (peek().type == Token::Type::Semicolon)
+               {
+                       advance();
+               }
+
+               return std::make_unique<FunctionNode>(p_kind, std::move(header), std::move(body));
+       }
+
+       std::unique_ptr<ASTNode> Lexer::parseNamespace()
+       {
+               Token nameTok = expect(Token::Type::Namespace);
+               Token ident = expect(Token::Type::Identifier);
+               auto bodyAst = parseCompound();
+               auto body = std::unique_ptr<CompoundNode>(static_cast<CompoundNode*>(bodyAst.release()));
+               return std::make_unique<NamespaceNode>(ident, std::move(body));
+       }
+
+       std::unique_ptr<ASTNode> Lexer::parseStruct()
+       {
+               Token kw = expect(Token::Type::Struct);
+               Token ident = expect(Token::Type::Identifier);
+               bool prev = _inStruct;
+               _inStruct = true;
+               auto bodyAst = parseCompound();
+               _inStruct = prev;
+               auto body = std::unique_ptr<CompoundNode>(static_cast<CompoundNode*>(bodyAst.release()));
+               expect(Token::Type::Semicolon, "Expected ';'");
+               return std::make_unique<StructureNode>(ident, std::move(body));
+       }
+
+       std::unique_ptr<ASTNode> Lexer::parseAttributeBlock()
+       {
+               Token kw = expect(Token::Type::AttributeBlock);
+               Token ident = expect(Token::Type::Identifier);
+               bool prev = _inStruct;
+               _inStruct = true;
+               auto bodyAst = parseCompound();
+               _inStruct = prev;
+               auto body = std::unique_ptr<CompoundNode>(static_cast<CompoundNode*>(bodyAst.release()));
+               expect(Token::Type::Semicolon, "Expected ';'");
+               return std::make_unique<AttributeBlockNode>(ident, std::move(body));
+       }
+
+       std::unique_ptr<ASTNode> Lexer::parseConstantBlock()
+       {
+               Token kw = expect(Token::Type::ConstantBlock);
+               Token ident = expect(Token::Type::Identifier);
+               bool prev = _inStruct;
+               _inStruct = true;
+               auto bodyAst = parseCompound();
+               _inStruct = prev;
+               auto body = std::unique_ptr<CompoundNode>(static_cast<CompoundNode*>(bodyAst.release()));
+               expect(Token::Type::Semicolon, "Expected ';'");
+               return std::make_unique<ConstantBlockNode>(ident, std::move(body));
+       }
+
+       std::unique_ptr<ASTNode> Lexer::parseTexture()
+       {
+               Token kw = expect(Token::Type::Texture);
+               Token ident = expect(Token::Type::Identifier);
+               expect(Token::Type::Semicolon, "Expected ';'");
+               (void)kw;
+               return std::make_unique<TextureNode>(ident);
+       }
+
+       std::unique_ptr<ASTNode> Lexer::parseInclude()
+       {
+               Token hash = expect(Token::Type::Preprocessor);
+               Token kw = expect(Token::Type::Include);
+
+               bool system = false;
+               std::vector<Token> path;
+
+               if (peek().type == Token::Type::Less)
+               {
+                       system = true;
+                       advance();
+                       while (!eof() && peek().type != Token::Type::Greater)
+                       {
+                               path.emplace_back(advance());
+                       }
+                       expect(Token::Type::Greater, "Expected '>'");
+               }
+               else
+               {
+                       path.emplace_back(expect({Token::Type::StringLiteral, Token::Type::Identifier}));
+               }
+
+               (void)kw;
+               return std::make_unique<IncludeNode>(std::move(path), system, hash.location);
+       }
+
+       std::unique_ptr<ASTNode> Lexer::parseShader()
+       {
+               Token first = expect(Token::Type::ShaderPass);
+               if (peek().type == Token::Type::Arrow)
+               {
+                       advance();
+                       Token second = expect(Token::Type::ShaderPass);
+                       expect(Token::Type::Colon);
+                       std::vector<Token> decl;
+                       while (!eof() && peek().type != Token::Type::Semicolon)
+                       {
+                               decl.emplace_back(advance());
+                       }
+                       expect(Token::Type::Semicolon, "Expected ';'");
+                       return std::make_unique<PipelineDefinitionNode>(first, second, std::move(decl));
+               }
+
+               expect(Token::Type::OpenParenthesis);
+               expect(Token::Type::CloseParenthesis);
+               auto bodyAst = parseCompound();
+               auto body = std::unique_ptr<CompoundNode>(static_cast<CompoundNode*>(bodyAst.release()));
+               return std::make_unique<PipelineBodyNode>(first, std::move(body));
+       }
+
+       std::unique_ptr<ASTNode> Lexer::parseGeneric()
+       {
+               if (isFunctionStart())
+               {
+                       ASTNode::Kind kind = _inStruct ? ASTNode::Kind::Method : ASTNode::Kind::Function;
+                       return parseFunction(kind);
+               }
+               return std::make_unique<TokenNode>(advance());
+       }
+
+       std::unique_ptr<ASTNode> Lexer::parseCompound()
+       {
+               Location loc = expect(Token::Type::OpenCurlyBracket).location;
+               auto node = std::make_unique<CompoundNode>(loc);
+               while (!eof())
+               {
+                       skipComment();
+                       if (peek().type == Token::Type::CloseCurlyBracket)
+                       {
+                               break;
+                       }
+
+                       auto it = _dispatch.find(peek().type);
+                       if (it == _dispatch.end())
+                       {
+                               node->children.emplace_back(parseGeneric());
+                               continue;
+                       }
+
+                       node->children.emplace_back((this->*it->second)());
+               }
+               expect(Token::Type::CloseCurlyBracket, "Expected '}'");
+               return node;
+       }
 
 	static std::string makeUnexpected(const Token &p_tok)
 	{
@@ -99,14 +283,16 @@ namespace spk::Lumina
 				break;
 			}
 
-			auto it = _dispatch.find(peek().type);
-			if (it == _dispatch.end())
-			{
-				throw TokenException{makeUnexpected(peek()), peek(), _sourceManager};
-			}
-
-			result.emplace_back((this->*it->second)());
-		}
-		return result;
-	}
+                       auto it = _dispatch.find(peek().type);
+                       if (it == _dispatch.end())
+                       {
+                               result.emplace_back(parseGeneric());
+                       }
+                       else
+                       {
+                               result.emplace_back((this->*it->second)());
+                       }
+               }
+               return result;
+       }
 }


### PR DESCRIPTION
## Summary
- define `IncludeNode` and enum entry for include statements
- allow lexer to parse `#include` directives and construct IncludeNode

## Testing
- `cmake -S . -B build` *(fails: Could NOT find GLEW)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68755ce92804832596aabf09d0013595