### PR TITLE
Extend Lumina AST

### DIFF
--- a/doc/lumina_ast_elements.md
+++ b/doc/lumina_ast_elements.md
@@ -1,0 +1,37 @@
+# Lumina AST Elements
+
+This document enumerates the different kinds of nodes that compose the Abstract Syntax Tree (AST) used by the Lumina compiler. Each node represents a specific syntactic element that can appear in Lumina source code.
+
+## High level constructs
+- **Namespace** – groups related declarations under a common scope.
+- **Structure** – user defined type containing variables and methods.
+- **AttributeBlock** – uniform block shared for a single draw call.
+- **ConstantBlock** – uniform block shared across all pipeline executions.
+- **Texture** – declaration of a 2D texture object.
+- **PipelineDefinition** – declaration of data flow between shader stages.
+- **PipelineBody** – body of a shader stage such as `VertexPass` or `FragmentPass`.
+- **Function/Method** – function outside/inside a structure.
+- **Include** – `#include` directive.
+
+## Statements
+- **Compound** – a list of child statements enclosed in braces.
+- **VariableDeclaration** – declares a new variable optionally with an initializer.
+- **Assignment** – assigns a value to an existing l-value. Includes compound assignments (+=, -=, ...).
+- **IfStatement** – conditional execution with optional `else` branch.
+- **ForLoop** – classic `for(initializer; condition; increment)` loop.
+- **WhileLoop** – `while(condition)` loop.
+- **ReturnStatement** – returns a value from a function or method.
+- **DiscardStatement** – discards the current fragment.
+
+## Expressions
+- **BinaryExpression** – expression with a binary operator (`+`, `-`, `*`, `/`, etc.).
+- **UnaryExpression** – expression with a unary operator (`-`, `!`, `++`, `--`, ...).
+- **CallExpression** – function or method invocation.
+- **MemberAccess** – access to a member of a structure (dot or arrow).
+- **VariableReference** – use of an identifier.
+- **Literal** – numeric, boolean or string constant.
+- **TernaryExpression** – conditional operator `? :`.
+- **LValue** – expression that can appear on the left side of an assignment.
+- **RValue** – expression yielding a value.
+
+This list defines the nodes that will be represented in the AST. Every syntactic element of the language is built from these primitives.

--- a/include/structure/graphics/lumina/compiler/spk_ast.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_ast.hpp
@@ -13,21 +13,37 @@ namespace spk::Lumina
 {
         struct ASTNode
         {
-                enum class Kind
-                {
-                        Token,
-                        Compound,
-                        Namespace,
-                        Structure,
-                        AttributeBlock,
-                        ConstantBlock,
+               enum class Kind
+               {
+                       Token,
+                       Compound,
+                       Namespace,
+                       Structure,
+                       AttributeBlock,
+                       ConstantBlock,
                        Texture,
                        Include,
                        Function,
-                        Method,
-                        PipelineDefinition,
-                        PipelineBody
-                };
+                       Method,
+                       PipelineDefinition,
+                       PipelineBody,
+                       VariableDeclaration,
+                       Assignment,
+                       IfStatement,
+                       ForLoop,
+                       WhileLoop,
+                       ReturnStatement,
+                       DiscardStatement,
+                       BinaryExpression,
+                       UnaryExpression,
+                       CallExpression,
+                       MemberAccess,
+                       VariableReference,
+                       Literal,
+                       TernaryExpression,
+                       LValue,
+                       RValue
+               };
 
 		Location location;
 		Kind kind;
@@ -199,6 +215,245 @@ namespace spk::Lumina
                        ASTNode(Kind::Include, std::move(p_loc)),
                        path(std::move(p_path)),
                        system(p_system)
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct VariableDeclarationNode : public ASTNode
+       {
+               Token typeName;
+               Token name;
+               std::unique_ptr<ASTNode> initializer;
+
+               VariableDeclarationNode(Token p_type, Token p_name, std::unique_ptr<ASTNode> p_init) :
+                       ASTNode(Kind::VariableDeclaration, p_type.location),
+                       typeName(p_type),
+                       name(p_name),
+                       initializer(std::move(p_init))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct AssignmentNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> target;
+               Token op;
+               std::unique_ptr<ASTNode> value;
+
+               AssignmentNode(std::unique_ptr<ASTNode> p_target, Token p_op, std::unique_ptr<ASTNode> p_value) :
+                       ASTNode(Kind::Assignment, p_op.location),
+                       target(std::move(p_target)),
+                       op(p_op),
+                       value(std::move(p_value))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct IfStatementNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> condition;
+               std::unique_ptr<CompoundNode> thenBody;
+               std::unique_ptr<CompoundNode> elseBody;
+
+               IfStatementNode(std::unique_ptr<ASTNode> p_cond, std::unique_ptr<CompoundNode> p_then, std::unique_ptr<CompoundNode> p_else, Location p_loc) :
+                       ASTNode(Kind::IfStatement, std::move(p_loc)),
+                       condition(std::move(p_cond)),
+                       thenBody(std::move(p_then)),
+                       elseBody(std::move(p_else))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct ForLoopNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> init;
+               std::unique_ptr<ASTNode> condition;
+               std::unique_ptr<ASTNode> increment;
+               std::unique_ptr<CompoundNode> body;
+
+               ForLoopNode(std::unique_ptr<ASTNode> p_init, std::unique_ptr<ASTNode> p_cond, std::unique_ptr<ASTNode> p_inc, std::unique_ptr<CompoundNode> p_body, Location p_loc) :
+                       ASTNode(Kind::ForLoop, std::move(p_loc)),
+                       init(std::move(p_init)),
+                       condition(std::move(p_cond)),
+                       increment(std::move(p_inc)),
+                       body(std::move(p_body))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct WhileLoopNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> condition;
+               std::unique_ptr<CompoundNode> body;
+
+               WhileLoopNode(std::unique_ptr<ASTNode> p_cond, std::unique_ptr<CompoundNode> p_body, Location p_loc) :
+                       ASTNode(Kind::WhileLoop, std::move(p_loc)),
+                       condition(std::move(p_cond)),
+                       body(std::move(p_body))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct ReturnStatementNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> value;
+
+               ReturnStatementNode(std::unique_ptr<ASTNode> p_value, Location p_loc) :
+                       ASTNode(Kind::ReturnStatement, std::move(p_loc)),
+                       value(std::move(p_value))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct DiscardStatementNode : public ASTNode
+       {
+               explicit DiscardStatementNode(Location p_loc) :
+                       ASTNode(Kind::DiscardStatement, std::move(p_loc))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct BinaryExpressionNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> left;
+               Token op;
+               std::unique_ptr<ASTNode> right;
+
+               BinaryExpressionNode(std::unique_ptr<ASTNode> p_left, Token p_op, std::unique_ptr<ASTNode> p_right, Location p_loc) :
+                       ASTNode(Kind::BinaryExpression, std::move(p_loc)),
+                       left(std::move(p_left)),
+                       op(p_op),
+                       right(std::move(p_right))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct UnaryExpressionNode : public ASTNode
+       {
+               Token op;
+               std::unique_ptr<ASTNode> operand;
+
+               UnaryExpressionNode(Token p_op, std::unique_ptr<ASTNode> p_operand, Location p_loc) :
+                       ASTNode(Kind::UnaryExpression, std::move(p_loc)),
+                       op(p_op),
+                       operand(std::move(p_operand))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct CallExpressionNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> callee;
+               std::vector<std::unique_ptr<ASTNode>> arguments;
+
+               CallExpressionNode(std::unique_ptr<ASTNode> p_callee, std::vector<std::unique_ptr<ASTNode>> p_args, Location p_loc) :
+                       ASTNode(Kind::CallExpression, std::move(p_loc)),
+                       callee(std::move(p_callee)),
+                       arguments(std::move(p_args))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct MemberAccessNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> object;
+               Token member;
+
+               MemberAccessNode(std::unique_ptr<ASTNode> p_obj, Token p_member, Location p_loc) :
+                       ASTNode(Kind::MemberAccess, std::move(p_loc)),
+                       object(std::move(p_obj)),
+                       member(p_member)
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct VariableReferenceNode : public ASTNode
+       {
+               Token name;
+
+               explicit VariableReferenceNode(Token p_name) :
+                       ASTNode(Kind::VariableReference, p_name.location),
+                       name(p_name)
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct LiteralNode : public ASTNode
+       {
+               Token value;
+
+               explicit LiteralNode(Token p_val) :
+                       ASTNode(Kind::Literal, p_val.location),
+                       value(p_val)
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct TernaryExpressionNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> condition;
+               std::unique_ptr<ASTNode> thenExpr;
+               std::unique_ptr<ASTNode> elseExpr;
+
+               TernaryExpressionNode(std::unique_ptr<ASTNode> p_cond, std::unique_ptr<ASTNode> p_then, std::unique_ptr<ASTNode> p_else, Location p_loc) :
+                       ASTNode(Kind::TernaryExpression, std::move(p_loc)),
+                       condition(std::move(p_cond)),
+                       thenExpr(std::move(p_then)),
+                       elseExpr(std::move(p_else))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct LValueNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> expression;
+
+               explicit LValueNode(std::unique_ptr<ASTNode> p_expr, Location p_loc) :
+                       ASTNode(Kind::LValue, std::move(p_loc)),
+                       expression(std::move(p_expr))
+               {
+               }
+
+               void print(std::wostream &p_os, size_t p_indent = 0) const override;
+       };
+
+       struct RValueNode : public ASTNode
+       {
+               std::unique_ptr<ASTNode> expression;
+
+               explicit RValueNode(std::unique_ptr<ASTNode> p_expr, Location p_loc) :
+                       ASTNode(Kind::RValue, std::move(p_loc)),
+                       expression(std::move(p_expr))
                {
                }
 

--- a/src/structure/graphics/lumina/compiler/spk_ast.cpp
+++ b/src/structure/graphics/lumina/compiler/spk_ast.cpp
@@ -19,6 +19,22 @@ namespace spk::Lumina
                        case ASTNode::Kind::Method:               return L"Method";
                        case ASTNode::Kind::PipelineDefinition:   return L"PipelineDefinition";
                        case ASTNode::Kind::PipelineBody:         return L"PipelineBody";
+                       case ASTNode::Kind::VariableDeclaration:  return L"VariableDeclaration";
+                       case ASTNode::Kind::Assignment:           return L"Assignment";
+                       case ASTNode::Kind::IfStatement:          return L"IfStatement";
+                       case ASTNode::Kind::ForLoop:              return L"ForLoop";
+                       case ASTNode::Kind::WhileLoop:            return L"WhileLoop";
+                       case ASTNode::Kind::ReturnStatement:      return L"ReturnStatement";
+                       case ASTNode::Kind::DiscardStatement:     return L"DiscardStatement";
+                       case ASTNode::Kind::BinaryExpression:     return L"BinaryExpression";
+                       case ASTNode::Kind::UnaryExpression:      return L"UnaryExpression";
+                       case ASTNode::Kind::CallExpression:       return L"CallExpression";
+                       case ASTNode::Kind::MemberAccess:         return L"MemberAccess";
+                       case ASTNode::Kind::VariableReference:    return L"VariableReference";
+                       case ASTNode::Kind::Literal:              return L"Literal";
+                       case ASTNode::Kind::TernaryExpression:    return L"TernaryExpression";
+                       case ASTNode::Kind::LValue:               return L"LValue";
+                       case ASTNode::Kind::RValue:               return L"RValue";
                        default:                                  return L"(Invalid)";
                }
        }
@@ -146,5 +162,188 @@ namespace spk::Lumina
                        p_os << L">";
                }
                p_os << std::endl;
+       }
+
+       void VariableDeclarationNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"VariableDeclaration " << typeName.lexeme << L" " << name.lexeme;
+               if (initializer)
+               {
+                       p_os << L" =" << std::endl;
+                       initializer->print(p_os, p_indent + 2);
+               }
+               else
+               {
+                       p_os << L";" << std::endl;
+               }
+       }
+
+       void AssignmentNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ');
+               if (target)
+               {
+                       target->print(p_os, 0);
+               }
+               p_os << L" " << op.lexeme << L" ";
+               if (value)
+               {
+                       value->print(p_os, 0);
+               }
+               p_os << std::endl;
+       }
+
+       void IfStatementNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"If(";
+               if (condition)
+               {
+                       condition->print(p_os, 0);
+               }
+               p_os << L")" << std::endl;
+               if (thenBody)
+               {
+                       thenBody->print(p_os, p_indent + 2);
+               }
+               if (elseBody)
+               {
+                       p_os << std::wstring(p_indent, L' ') << L"else" << std::endl;
+                       elseBody->print(p_os, p_indent + 2);
+               }
+       }
+
+       void ForLoopNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"For" << std::endl;
+               if (body)
+               {
+                       body->print(p_os, p_indent + 2);
+               }
+       }
+
+       void WhileLoopNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"While" << std::endl;
+               if (body)
+               {
+                       body->print(p_os, p_indent + 2);
+               }
+       }
+
+       void ReturnStatementNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"Return";
+               if (value)
+               {
+                       p_os << L" ";
+                       value->print(p_os, 0);
+               }
+               p_os << std::endl;
+       }
+
+       void DiscardStatementNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << L"Discard" << std::endl;
+       }
+
+       void BinaryExpressionNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ');
+               if (left)
+               {
+                       left->print(p_os, 0);
+               }
+               p_os << L" " << op.lexeme << L" ";
+               if (right)
+               {
+                       right->print(p_os, 0);
+               }
+       }
+
+       void UnaryExpressionNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << op.lexeme;
+               if (operand)
+               {
+                       operand->print(p_os, 0);
+               }
+       }
+
+       void CallExpressionNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ');
+               if (callee)
+               {
+                       callee->print(p_os, 0);
+               }
+               p_os << L"(";
+               bool first = true;
+               for (const auto &arg : arguments)
+               {
+                       if (!first)
+                       {
+                               p_os << L", ";
+                       }
+                       first = false;
+                       if (arg)
+                       {
+                               arg->print(p_os, 0);
+                       }
+               }
+               p_os << L")";
+       }
+
+       void MemberAccessNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ');
+               if (object)
+               {
+                       object->print(p_os, 0);
+               }
+               p_os << L"." << member.lexeme;
+       }
+
+       void VariableReferenceNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << name.lexeme;
+       }
+
+       void LiteralNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               p_os << std::wstring(p_indent, L' ') << value.lexeme;
+       }
+
+       void TernaryExpressionNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               if (condition)
+               {
+                       condition->print(p_os, p_indent);
+               }
+               p_os << L" ? ";
+               if (thenExpr)
+               {
+                       thenExpr->print(p_os, 0);
+               }
+               p_os << L" : ";
+               if (elseExpr)
+               {
+                       elseExpr->print(p_os, 0);
+               }
+       }
+
+       void LValueNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               if (expression)
+               {
+                       expression->print(p_os, p_indent);
+               }
+       }
+
+       void RValueNode::print(std::wostream &p_os, size_t p_indent) const
+       {
+               if (expression)
+               {
+                       expression->print(p_os, p_indent);
+               }
        }
 }


### PR DESCRIPTION
## Summary
- document every AST element type
- expand `ASTNode::Kind` enumeration with more node types
- provide data structures for every element in `spk_ast.hpp`
- implement string conversion and printing for new nodes

## Testing
- `clang-format -i include/structure/graphics/lumina/compiler/spk_ast.hpp` *(fails: unknown key 'BeforeBlock')*
- `clang-format --version`

------
https://chatgpt.com/codex/tasks/task_e_687584339cf48325b77cb4ccb3885c6a