### PR TITLE
Fix pipeline variable support in analyzer

### DIFF
--- a/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
@@ -45,6 +45,7 @@ namespace spk::Lumina
         void _pushScope();
         void _popScope();
         void _loadBuiltinTypes();
+        void _loadBuiltinVariables();
         std::wstring _evaluate(const ASTNode* p_node);
 
         void _pushContainer(const std::wstring& p_name);


### PR DESCRIPTION
## Summary
- recognise builtin variables `pixelColor` and `pixelPosition`
- treat pipeline flow declarations as variable declarations so names like `fragmentColor` are available

## Testing
- `cmake --preset playground-debug` *(fails: Could not find toolchain file: C:/vcpkg/scripts/buildsystems/vcpkg.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_687a05109614832596ef3274698cb00c