### PR TITLE
Fix variable representation with type pointers

### DIFF
--- a/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
@@ -32,19 +32,64 @@ namespace spk::Lumina
 
         SourceManager& _sourceManager;
         std::unordered_set<std::wstring> _pipelineStages;
-        std::unordered_set<std::wstring> _types;
-        std::unordered_set<std::wstring> _textures;
-        std::unordered_map<std::wstring, std::unordered_set<std::wstring>> _functionSignatures;
+        struct TypeSymbol;
+
+        struct Variable
+        {
+            std::wstring name;
+            TypeSymbol* type = nullptr;
+        };
+
+        struct TypeSymbol
+        {
+            std::wstring name;
+            std::unordered_set<TypeSymbol*> convertible;
+            std::vector<Variable> members;
+            std::vector<FunctionSymbol> constructors;
+            std::unordered_map<std::wstring, std::vector<FunctionSymbol>> operators;
+        };
+
+        struct NamespaceSymbol
+        {
+            std::wstring name;
+            std::vector<NamespaceSymbol> namespaces;
+            std::vector<TypeSymbol*> structures;
+            std::vector<std::wstring> attributeBlocks;
+            std::vector<std::wstring> constantBlocks;
+            std::vector<Variable> textures;
+            std::unordered_map<std::wstring, TypeSymbol> types;
+            std::unordered_map<std::wstring, std::vector<FunctionSymbol>> functionSignatures;
+            std::vector<FunctionSymbol> functions;
+        };
+
+        struct FunctionSymbol
+        {
+            std::wstring name;
+            std::wstring returnType;
+            std::vector<std::wstring> parameters;
+            std::wstring signature;
+        };
+
         std::vector<std::wstring> _containerStack;
         std::unordered_set<std::wstring> _includedFiles;
         std::vector<std::wstring> _includeStack;
-        struct Symbol { std::wstring type; };
-        std::vector<std::unordered_map<std::wstring, Symbol>> _scopes;
+        std::vector<std::unordered_map<std::wstring, Variable>> _scopes;
+        NamespaceSymbol _anonymousNamespace;
+        std::vector<NamespaceSymbol*> _namespaceStack;
+        std::unordered_set<std::wstring> _namespaceNames;
         std::unordered_map<ASTNode::Kind, AnalyzeFn> _dispatch;
 
         void _pushScope();
         void _popScope();
         void _loadBuiltinTypes();
+        void _loadBuiltinVariables();
+        void _loadBuiltinFunctions();
+        TypeSymbol* _findType(const std::wstring& p_name) const;
+        const NamespaceSymbol* _findNamespace(const std::wstring& p_name) const;
+        std::wstring _conversionInfo(const std::wstring& p_from) const;
+        std::wstring _extractCalleeName(const ASTNode* p_node) const;
+        std::vector<std::wstring> _parseParameters(const std::vector<Token>& p_header) const;
+        std::vector<FunctionSymbol> _findFunctions(const std::wstring& p_name) const;
         std::wstring _evaluate(const ASTNode* p_node);
 
         void _pushContainer(const std::wstring& p_name);


### PR DESCRIPTION
## Summary
- keep pointers to `TypeSymbol` for implicit conversions
- parse builtin docs with new pointer-based storage
- show convertible type names via `_conversionInfo`
- track namespaces and builtin shader entry points
- store struct members in vectors instead of maps
- move types, textures and functions into `NamespaceSymbol`
- store textures as actual `Variable` entries

## Testing
- `cmake --preset playground-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_687a05109614832596ef3274698cb00c