### PR TITLE
Store parsed bodies within shader data

### DIFF
--- a/include/structure/graphics/lumina/compiler/data/spk_shader_data.hpp
+++ b/include/structure/graphics/lumina/compiler/data/spk_shader_data.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_set>
+#include <unordered_map>
+#include <ostream>
+#include "structure/graphics/lumina/compiler/spk_ast.hpp"
+
+namespace spk::Lumina
+{
+    struct TypeSymbol;
+
+struct Variable
+    {
+        std::wstring name;
+        TypeSymbol* type = nullptr;
+    void print(std::wostream& os, size_t indent = 0) const;
+};
+
+    struct Statement
+    {
+        ASTNode::Kind kind = ASTNode::Kind::Token;
+        std::wstring text;
+        std::vector<Statement> children;
+        void print(std::wostream& os, size_t indent = 0) const;
+    };
+
+    struct FunctionSymbol
+    {
+        std::wstring name;
+        const TypeSymbol* returnType = nullptr;
+        std::vector<Variable> parameters;
+        // Normalized representation of the function header
+        std::wstring signature;
+        std::vector<Statement> body;
+        void print(std::wostream& os, size_t indent = 0) const;
+    };
+
+struct TypeSymbol
+{
+    enum class Role
+    {
+        Structure,
+        Attribute,
+        Constant
+    };
+
+    std::wstring name;
+    Role role = Role::Structure;
+    std::unordered_set<TypeSymbol*> convertible;
+    std::vector<Variable> members;
+    std::vector<FunctionSymbol> constructors;
+    std::unordered_map<std::wstring, std::vector<FunctionSymbol>> operators;
+    void print(std::wostream& os, size_t indent = 0) const;
+    };
+
+struct NamespaceSymbol
+    {
+        std::wstring name;
+        std::vector<NamespaceSymbol> namespaces;
+        std::vector<TypeSymbol*> structures;
+        std::vector<std::wstring> attributeBlocks;
+        std::vector<std::wstring> constantBlocks;
+        std::vector<Variable> textures;
+        std::unordered_map<std::wstring, TypeSymbol> types;
+        std::unordered_map<std::wstring, std::vector<FunctionSymbol>> functionSignatures;
+        std::vector<FunctionSymbol> functions;
+        void print(std::wostream& os, size_t indent = 0) const;
+    };
+
+    struct PipelineStage
+    {
+        std::wstring stage;
+        std::vector<Statement> body;
+        void print(std::wostream& os, size_t indent = 0) const;
+    };
+
+    struct ShaderData
+    {
+        NamespaceSymbol globalNamespace;
+        std::vector<PipelineStage> pipelineStages;
+        void print(std::wostream& os, size_t indent = 0) const;
+    };
+
+    std::wostream& operator<<(std::wostream& os, const ShaderData& data);
+}
+

--- a/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
@@ -9,6 +9,7 @@
 
 #include "structure/graphics/lumina/compiler/spk_ast.hpp"
 #include "structure/graphics/lumina/compiler/spk_source_manager.hpp"
+#include "structure/graphics/lumina/compiler/data/spk_shader_data.hpp"
 
 namespace spk::Lumina
 {
@@ -27,54 +28,25 @@ namespace spk::Lumina
 
         void run(const std::vector<std::unique_ptr<ASTNode>>& p_nodes);
 
+        const ShaderData& getData() const { return _shaderData; }
+
     private:
         using AnalyzeFn = void (Analyzer::*)(const ASTNode*);
 
         SourceManager& _sourceManager;
         std::unordered_set<std::wstring> _pipelineStages;
-        struct TypeSymbol;
-
-        struct Variable
-        {
-            std::wstring name;
-            TypeSymbol* type = nullptr;
-        };
-
-        struct TypeSymbol
-        {
-            std::wstring name;
-            std::unordered_set<TypeSymbol*> convertible;
-            std::vector<Variable> members;
-            std::vector<FunctionSymbol> constructors;
-            std::unordered_map<std::wstring, std::vector<FunctionSymbol>> operators;
-        };
-
-        struct NamespaceSymbol
-        {
-            std::wstring name;
-            std::vector<NamespaceSymbol> namespaces;
-            std::vector<TypeSymbol*> structures;
-            std::vector<std::wstring> attributeBlocks;
-            std::vector<std::wstring> constantBlocks;
-            std::vector<Variable> textures;
-            std::unordered_map<std::wstring, TypeSymbol> types;
-            std::unordered_map<std::wstring, std::vector<FunctionSymbol>> functionSignatures;
-            std::vector<FunctionSymbol> functions;
-        };
-
-        struct FunctionSymbol
-        {
-            std::wstring name;
-            std::wstring returnType;
-            std::vector<std::wstring> parameters;
-            std::wstring signature;
-        };
+        using Variable = spk::Lumina::Variable;
+        using FunctionSymbol = spk::Lumina::FunctionSymbol;
+        using TypeSymbol = spk::Lumina::TypeSymbol;
+        using NamespaceSymbol = spk::Lumina::NamespaceSymbol;
+        using Statement = spk::Lumina::Statement;
+        using PipelineStage = spk::Lumina::PipelineStage;
 
         std::vector<std::wstring> _containerStack;
         std::unordered_set<std::wstring> _includedFiles;
         std::vector<std::wstring> _includeStack;
         std::vector<std::unordered_map<std::wstring, Variable>> _scopes;
-        NamespaceSymbol _anonymousNamespace;
+        ShaderData _shaderData;
         std::vector<NamespaceSymbol*> _namespaceStack;
         std::unordered_set<std::wstring> _namespaceNames;
         std::unordered_map<ASTNode::Kind, AnalyzeFn> _dispatch;
@@ -88,7 +60,7 @@ namespace spk::Lumina
         const NamespaceSymbol* _findNamespace(const std::wstring& p_name) const;
         std::wstring _conversionInfo(const std::wstring& p_from) const;
         std::wstring _extractCalleeName(const ASTNode* p_node) const;
-        std::vector<std::wstring> _parseParameters(const std::vector<Token>& p_header) const;
+        std::vector<Variable> _parseParameters(const std::vector<Token>& p_header) const;
         std::vector<FunctionSymbol> _findFunctions(const std::wstring& p_name) const;
         std::wstring _evaluate(const ASTNode* p_node);
 
@@ -96,6 +68,7 @@ namespace spk::Lumina
         void _popContainer();
         std::wstring _currentContext() const;
         std::wstring _makeSignature(const std::vector<Token>& p_header) const;
+        Statement _convertAST(const ASTNode* p_node) const;
 
         void _analyze(const ASTNode* p_node);
 

--- a/src/structure/graphics/lumina/compiler/data/spk_shader_data.cpp
+++ b/src/structure/graphics/lumina/compiler/data/spk_shader_data.cpp
@@ -1,0 +1,109 @@
+#include "structure/graphics/lumina/compiler/data/spk_shader_data.hpp"
+#include <algorithm>
+
+namespace spk::Lumina
+{
+namespace
+{
+    bool contains(const std::vector<std::wstring>& vec, const std::wstring& name)
+    {
+        return std::find(vec.begin(), vec.end(), name) != vec.end();
+    }
+}
+
+void Variable::print(std::wostream& os, size_t indent) const
+{
+    std::wstring ind(indent, L'\t');
+    os << ind << (type ? type->name : L"void") << L" " << name;
+}
+
+void Statement::print(std::wostream& os, size_t indent) const
+{
+    std::wstring ind(indent, L'\t');
+    os << ind << to_wstring(kind);
+    if (!text.empty())
+        os << L": " << text;
+    os << L"\n";
+    for (const auto& child : children)
+        child.print(os, indent + 1);
+}
+
+void FunctionSymbol::print(std::wostream& os, size_t indent) const
+{
+    std::wstring ind(indent, L'\t');
+    os << ind << L"Function: " << name << L"(";
+    for (size_t i = 0; i < parameters.size(); ++i)
+    {
+        parameters[i].print(os);
+        if (i + 1 < parameters.size())
+            os << L", ";
+    }
+    os << L") -> " << (returnType ? returnType->name : L"void") << L"\n";
+    for (const auto& stmt : body)
+        stmt.print(os, indent + 1);
+}
+
+void TypeSymbol::print(std::wostream& os, size_t indent) const
+{
+    std::wstring ind(indent, L'\t');
+    std::wstring kind;
+    switch (role)
+    {
+    case Role::Attribute:
+        kind = L"AttributeBlock";
+        break;
+    case Role::Constant:
+        kind = L"ConstantBlock";
+        break;
+    default:
+        kind = L"Structure";
+        break;
+    }
+    os << ind << kind << L": " << name << L"\n";
+    size_t nextIndent = indent + 1;
+    for (const auto& member : members)
+    {
+        member.print(os, nextIndent);
+        os << L"\n";
+    }
+}
+
+void NamespaceSymbol::print(std::wostream& os, size_t indent) const
+{
+    std::wstring ind(indent, L'\t');
+    os << ind << L"Namespace: " << name << L"\n";
+    size_t nextIndent = indent + 1;
+
+    for (const auto& [n, t] : types)
+    {
+        t.print(os, nextIndent);
+    }
+
+    for (const auto& func : functions)
+        func.print(os, nextIndent);
+
+    for (const auto& ns : namespaces)
+        ns.print(os, nextIndent);
+}
+
+void PipelineStage::print(std::wostream& os, size_t indent) const
+{
+    std::wstring ind(indent, L'\t');
+    os << ind << L"PipelineStage: " << stage << L"\n";
+    for (const auto& stmt : body)
+        stmt.print(os, indent + 1);
+}
+
+void ShaderData::print(std::wostream& os, size_t indent) const
+{
+    globalNamespace.print(os, indent);
+    for (const auto& stage : pipelineStages)
+        stage.print(os, indent);
+}
+
+std::wostream& operator<<(std::wostream& os, const ShaderData& data)
+{
+    data.print(os);
+    return os;
+}
+}


### PR DESCRIPTION
## Summary
- represent shader statements with a new `Statement` struct and pipeline stages
- keep function and pipeline bodies in `ShaderData`
- add printing utilities for new structures
- convert AST nodes to `Statement` objects during analysis

## Testing
- `cmake -S . -B build` *(fails to find GLEW)*
- `cmake --build build -j$(nproc)` *(fails: Makefile missing due to prior error)*

------
https://chatgpt.com/codex/tasks/task_e_687b500e1e288325865d10b501e59fe1