### PR TITLE
Fix constructor parsing

### DIFF
--- a/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
@@ -62,6 +62,11 @@ namespace spk::Lumina
         std::wstring _extractCalleeName(const ASTNode* p_node) const;
         std::vector<Variable> _parseParameters(const std::vector<Token>& p_header) const;
         std::vector<FunctionSymbol> _findFunctions(const std::wstring& p_name) const;
+        bool _canConvert(const std::wstring& from, const std::wstring& to) const;
+        std::wstring _resolveCall(const ASTNode* callee,
+                                  const std::wstring& name,
+                                  const std::vector<std::wstring>& argTypes,
+                                  const Location& loc);
         std::wstring _evaluate(const ASTNode* p_node);
 
         void _pushContainer(const std::wstring& p_name);


### PR DESCRIPTION
## Summary
- allow constructor calls by falling back to type names
- validate constructor parameters and report mismatch
- centralize overload and constructor lookup

## Testing
- `cmake -S . -B build -DENABLE_TESTS=ON` *(fails: Could NOT find GLEW)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_687bae7d4528832586a966a858367b74