### PR TITLE
Add namespace type lookup

### DIFF
--- a/include/structure/graphics/lumina/compiler/spk_shader_data.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_shader_data.hpp
@@ -10,12 +10,13 @@
 namespace spk::Lumina
 {
     struct TypeSymbol;
+    struct NamespaceSymbol;
 
 struct Variable
     {
         std::wstring name;
         TypeSymbol* type = nullptr;
-    void print(std::wostream& os, size_t indent = 0) const;
+        void print(std::wostream& os, size_t indent = 0) const;
 };
 
     struct Statement
@@ -35,6 +36,12 @@ struct Variable
         std::wstring signature;
         std::vector<Statement> body;
         void print(std::wostream& os, size_t indent = 0) const;
+
+        FunctionSymbol() = default;
+        FunctionSymbol(const std::wstring& name,
+                       const TypeSymbol* returnType,
+                       const std::vector<Variable>& parameters,
+                       const std::vector<Statement>& body = {});
     };
 
 struct TypeSymbol
@@ -47,6 +54,7 @@ struct TypeSymbol
     };
 
     std::wstring name;
+    NamespaceSymbol* parent = nullptr;
     Role role = Role::Structure;
     std::unordered_set<TypeSymbol*> convertible;
     std::vector<Variable> members;
@@ -54,11 +62,25 @@ struct TypeSymbol
     std::vector<FunctionSymbol> methods;
     std::unordered_map<std::wstring, std::vector<FunctionSymbol>> operators;
     void print(std::wostream& os, size_t indent = 0) const;
-    };
+
+    TypeSymbol() = default;
+    TypeSymbol(const std::wstring& name,
+               Role role = Role::Structure,
+               NamespaceSymbol* parent = nullptr);
+
+    void addConstructor(const std::vector<Variable>& parameters);
+    void addMethod(TypeSymbol* returnType,
+                   const std::wstring& methodName,
+                   const std::vector<Variable>& parameters);
+    void addOperator(TypeSymbol* returnType,
+                     const std::wstring& operatorType,
+                     const std::vector<Variable>& parameters);
+};
 
 struct NamespaceSymbol
     {
         std::wstring name;
+        NamespaceSymbol* parent = nullptr;
         std::vector<NamespaceSymbol> namespaces;
         std::vector<TypeSymbol*> structures;
         std::vector<std::wstring> attributeBlocks;
@@ -68,6 +90,14 @@ struct NamespaceSymbol
         std::unordered_map<std::wstring, std::vector<FunctionSymbol>> functionSignatures;
         std::vector<FunctionSymbol> functions;
         void print(std::wostream& os, size_t indent = 0) const;
+
+        TypeSymbol* addType(const std::wstring& name,
+                            TypeSymbol::Role role = TypeSymbol::Role::Structure);
+        TypeSymbol* typeSymbol(const std::wstring& typeName) const;
+
+        void addFunction(TypeSymbol* returnType,
+                         const std::wstring& name,
+                         const std::vector<Variable>& parameters);
     };
 
     struct PipelineStage
@@ -77,7 +107,7 @@ struct NamespaceSymbol
         void print(std::wostream& os, size_t indent = 0) const;
     };
 
-    struct ShaderData
+struct ShaderData
     {
         NamespaceSymbol globalNamespace;
         std::vector<PipelineStage> pipelineStages;
@@ -85,5 +115,8 @@ struct NamespaceSymbol
     };
 
     std::wostream& operator<<(std::wostream& os, const ShaderData& data);
+
+    std::wstring composeSignature(const std::wstring& name,
+                                  const std::vector<Variable>& parameters);
 }
 

--- a/src/structure/graphics/lumina/compiler/spk_analyzer_build_in_definition.cpp
+++ b/src/structure/graphics/lumina/compiler/spk_analyzer_build_in_definition.cpp
@@ -2,49 +2,31 @@
 
 namespace spk::Lumina
 {
-	namespace
-	{
-		std::wstring composeSignature(const std::wstring& p_name, const std::vector<Variable> &p_parameters)
-		{
-			std::wstring result = L"";
-
-			result = p_name + L"(";
-			std::wstring parameterString = L"";
-			for (const auto &variable : p_parameters)
-			{
-				if (parameterString.empty() == false)
-				{
-					parameterString += L", ";
-				}
-				parameterString += variable.type->name;
-			}
-			result += parameterString + L")";
-		
-			return (result);
-		}
+       namespace
+       {
 
 		void registerBuiltinTypes(NamespaceSymbol &p_namespace)
 		{
 			auto &types = p_namespace.types;
 
-			types.emplace(L"float", TypeSymbol{L"float", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"int", TypeSymbol{L"int", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"uint", TypeSymbol{L"uint", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"bool", TypeSymbol{L"bool", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Vector2", TypeSymbol{L"Vector2", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Vector2Int", TypeSymbol{L"Vector2Int", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Vector2UInt", TypeSymbol{L"Vector2UInt", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Vector3", TypeSymbol{L"Vector3", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Vector3Int", TypeSymbol{L"Vector3Int", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Vector3UInt", TypeSymbol{L"Vector3UInt", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Vector4", TypeSymbol{L"Vector4", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Vector4Int", TypeSymbol{L"Vector4Int", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Vector4UInt", TypeSymbol{L"Vector4UInt", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Matrix2x2", TypeSymbol{L"Matrix2x2", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Matrix3x3", TypeSymbol{L"Matrix3x3", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Matrix4x4", TypeSymbol{L"Matrix4x4", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"Color", TypeSymbol{L"Color", TypeSymbol::Role::Structure, {}, {}, {}, {}});
-			types.emplace(L"void", TypeSymbol{L"void", TypeSymbol::Role::Structure, {}, {}, {}, {}});
+                       p_namespace.addType(L"float");
+                       p_namespace.addType(L"int");
+                       p_namespace.addType(L"uint");
+                       p_namespace.addType(L"bool");
+                       p_namespace.addType(L"Vector2");
+                       p_namespace.addType(L"Vector2Int");
+                       p_namespace.addType(L"Vector2UInt");
+                       p_namespace.addType(L"Vector3");
+                       p_namespace.addType(L"Vector3Int");
+                       p_namespace.addType(L"Vector3UInt");
+                       p_namespace.addType(L"Vector4");
+                       p_namespace.addType(L"Vector4Int");
+                       p_namespace.addType(L"Vector4UInt");
+                       p_namespace.addType(L"Matrix2x2");
+                       p_namespace.addType(L"Matrix3x3");
+                       p_namespace.addType(L"Matrix4x4");
+                       p_namespace.addType(L"Color");
+                       p_namespace.addType(L"void");
 
 			types[L"int"].convertible.insert(&types[L"float"]);
 			types[L"uint"].convertible.insert(&types[L"float"]);
@@ -73,73 +55,14 @@ namespace spk::Lumina
 
 		void registerBuiltinFunctions(NamespaceSymbol &p_namespace)
 		{
-			FunctionSymbol vertexPass;
-			vertexPass.name = L"VertexPass";
-			vertexPass.returnType = &p_namespace.types[L"void"];
-			vertexPass.signature = L"VertexPass()";
-			p_namespace.functionSignatures[L"VertexPass"].push_back(vertexPass);
-			p_namespace.functions.push_back(vertexPass);
+                        FunctionSymbol vertexPass(L"VertexPass", &p_namespace.types[L"void"], {});
+                        p_namespace.functionSignatures[L"VertexPass"].push_back(vertexPass);
+                        p_namespace.functions.push_back(vertexPass);
 
-			FunctionSymbol fragmentPass;
-			fragmentPass.name = L"FragmentPass";
-			fragmentPass.returnType = &p_namespace.types[L"void"];
-			fragmentPass.signature = L"FragmentPass()";
-			p_namespace.functionSignatures[L"FragmentPass"].push_back(fragmentPass);
-			p_namespace.functions.push_back(fragmentPass);
+                        FunctionSymbol fragmentPass(L"FragmentPass", &p_namespace.types[L"void"], {});
+                        p_namespace.functionSignatures[L"FragmentPass"].push_back(fragmentPass);
+                        p_namespace.functions.push_back(fragmentPass);
 
-			auto addFunction = [&](TypeSymbol* p_returnType, const std::wstring& p_methodName, const std::vector<Variable> &p_parameters)
-			{
-				FunctionSymbol newMethod;
-
-				newMethod.name = p_methodName;
-				newMethod.returnType = p_returnType;
-				newMethod.parameters = p_parameters;
-				newMethod.signature = composeSignature(newMethod.name, p_parameters);
-				newMethod.body = {};
-
-				p_namespace.functions.push_back(newMethod);
-			};
-
-			auto addConstructorType = [&](TypeSymbol* p_methodType, const std::vector<Variable> &p_parameters)
-			{
-				FunctionSymbol constructor;
-				
-				constructor.name = p_methodType->name;
-				constructor.returnType = p_methodType;
-				constructor.parameters = p_parameters;
-				constructor.signature = composeSignature(constructor.name, p_parameters);
-				constructor.body = {};
-
-				p_methodType->constructors.push_back(constructor);
-				p_namespace.functions.push_back(constructor);
-			};
-
-			auto addMethodToType = [&](TypeSymbol* p_methodType, TypeSymbol* p_returnType, const std::wstring& p_methodName, const std::vector<Variable> &p_parameters)
-			{
-				FunctionSymbol newMethod;
-
-				newMethod.name = p_methodName;
-				newMethod.returnType = p_returnType;
-				newMethod.parameters = p_parameters;
-				newMethod.signature = composeSignature(newMethod.name, p_parameters);
-				newMethod.body = {};
-
-				p_methodType->methods.push_back(newMethod);
-				p_namespace.functions.push_back(newMethod);
-			};
-
-			auto addOperatorToType = [&](TypeSymbol* p_methodType, TypeSymbol* p_returnType, const std::wstring& p_operatorType, const std::vector<Variable> &p_parameters){
-				FunctionSymbol newMethod;
-
-				newMethod.name = L"Operator" + p_operatorType;
-				newMethod.returnType = p_returnType;
-				newMethod.parameters = p_parameters;
-				newMethod.signature = composeSignature(newMethod.name, p_parameters);
-				newMethod.body = {};
-
-				p_methodType->methods.push_back(newMethod);
-				p_namespace.functions.push_back(newMethod);
-			};
 		}
 	} // namespace
 

--- a/src/structure/graphics/lumina/compiler/spk_shader_data.cpp
+++ b/src/structure/graphics/lumina/compiler/spk_shader_data.cpp
@@ -3,13 +3,33 @@
 
 namespace spk::Lumina
 {
-	namespace
-	{
-		bool contains(const std::vector<std::wstring> &p_vec, const std::wstring &p_name)
-		{
-			return std::find(p_vec.begin(), p_vec.end(), p_name) != p_vec.end();
-		}
-	}
+       namespace
+       {
+               bool contains(const std::vector<std::wstring> &p_vec, const std::wstring &p_name)
+               {
+                       return std::find(p_vec.begin(), p_vec.end(), p_name) != p_vec.end();
+               }
+       }
+
+       std::wstring composeSignature(const std::wstring &p_name,
+                                     const std::vector<Variable> &p_parameters)
+       {
+               std::wstring result = p_name + L"(";
+               std::wstring parameterString;
+               for (const auto &variable : p_parameters)
+               {
+                       if (!parameterString.empty())
+                       {
+                               parameterString += L", ";
+                       }
+                       if (variable.type)
+                       {
+                               parameterString += variable.type->name;
+                       }
+               }
+               result += parameterString + L")";
+               return result;
+       }
 
 	void Variable::print(std::wostream &p_os, size_t p_indent) const
 	{
@@ -122,9 +142,106 @@ namespace spk::Lumina
 		}
 	}
 
-	std::wostream &operator<<(std::wostream &p_os, const ShaderData &p_data)
-	{
-		p_data.print(p_os);
-		return p_os;
-	}
+       std::wostream &operator<<(std::wostream &p_os, const ShaderData &p_data)
+       {
+               p_data.print(p_os);
+               return p_os;
+       }
+
+       FunctionSymbol::FunctionSymbol(const std::wstring &p_name,
+                                      const TypeSymbol *p_returnType,
+                                      const std::vector<Variable> &p_parameters,
+                                      const std::vector<Statement> &p_body)
+               : name(p_name), returnType(p_returnType), parameters(p_parameters), body(p_body)
+       {
+               signature = composeSignature(name, parameters);
+       }
+
+       TypeSymbol::TypeSymbol(const std::wstring &p_name,
+                              Role p_role,
+                              NamespaceSymbol *p_parent)
+               : name(p_name), parent(p_parent), role(p_role)
+       {
+       }
+
+        void NamespaceSymbol::addFunction(TypeSymbol *p_returnType,
+                                          const std::wstring &p_name,
+                                          const std::vector<Variable> &p_parameters)
+        {
+                functions.emplace_back(p_name, p_returnType, p_parameters);
+        }
+
+        TypeSymbol *NamespaceSymbol::addType(const std::wstring &p_name,
+                                             TypeSymbol::Role p_role)
+        {
+                auto [it, inserted] = types.emplace(p_name, TypeSymbol(p_name, p_role));
+                it->second.parent = this;
+                return &it->second;
+        }
+
+        TypeSymbol *NamespaceSymbol::typeSymbol(const std::wstring &p_typeName) const
+        {
+                auto pos = p_typeName.find(L"::");
+                if (pos != std::wstring::npos)
+                {
+                        std::wstring nsName = p_typeName.substr(0, pos);
+                        std::wstring rest = p_typeName.substr(pos + 2);
+                        for (const auto &ns : namespaces)
+                        {
+                                if (ns.name == nsName)
+                                {
+                                        return ns.typeSymbol(rest);
+                                }
+                        }
+                        return nullptr;
+                }
+
+                auto it = types.find(p_typeName);
+                if (it != types.end())
+                {
+                        return const_cast<TypeSymbol *>(&it->second);
+                }
+                if (parent)
+                {
+                        return parent->typeSymbol(p_typeName);
+                }
+                return nullptr;
+        }
+
+        void TypeSymbol::addConstructor(const std::vector<Variable> &p_parameters)
+        {
+                FunctionSymbol constructor(name, this, p_parameters);
+
+                constructors.push_back(constructor);
+                if (parent)
+                {
+                        parent->functions.push_back(constructor);
+                }
+        }
+
+        void TypeSymbol::addMethod(TypeSymbol *p_returnType,
+                                   const std::wstring &p_methodName,
+                                   const std::vector<Variable> &p_parameters)
+        {
+                FunctionSymbol newMethod(p_methodName, p_returnType, p_parameters);
+
+                methods.push_back(newMethod);
+                if (parent)
+                {
+                        parent->functions.push_back(newMethod);
+                }
+        }
+
+        void TypeSymbol::addOperator(TypeSymbol *p_returnType,
+                                     const std::wstring &p_operatorType,
+                                     const std::vector<Variable> &p_parameters)
+        {
+                FunctionSymbol newMethod(L"Operator" + p_operatorType, p_returnType, p_parameters);
+
+                methods.push_back(newMethod);
+                if (parent)
+                {
+                        parent->functions.push_back(newMethod);
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- allow NamespaceSymbol to own child namespaces and types
- add helpers to insert types and search by name through namespace hierarchy
- update analyzer and builtin registration to use the new helpers

## Testing
- `cmake --preset test` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_687bd76ce8bc83258a4a0aee1e84d074