### PR TITLE
Improve constructor error output

### DIFF
--- a/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
@@ -76,6 +76,8 @@ namespace spk::Lumina
         void _popContainer();
         std::wstring _currentContext() const;
         std::wstring _makeSignature(const std::vector<Token>& p_header) const;
+        std::wstring _makeCallSignature(const std::wstring& name,
+                                        const std::vector<std::wstring>& argTypes) const;
         Statement _convertAST(const ASTNode* p_node) const;
 
         void _analyze(const ASTNode* p_node);


### PR DESCRIPTION
## Summary
- enhance Analyzer to show the call signature when no function/constructor is matched

## Testing
- `cmake --preset test-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_687bf2e3b1948325a33ab6443b9b503b