### PR TITLE
Add primitive operators and boolean comparison handling

### DIFF
--- a/src/structure/graphics/lumina/compiler/spk_analyzer_build_in_definition.cpp
+++ b/src/structure/graphics/lumina/compiler/spk_analyzer_build_in_definition.cpp
@@ -33,7 +33,41 @@ namespace spk::Lumina
 			types[L"uint"].convertible.insert(&types[L"float"]);
 			types[L"float"].convertible.insert(&types[L"int"]);
 			types[L"float"].convertible.insert(&types[L"uint"]);
-			types[L"uint"].convertible.insert(&types[L"int"]);
+                        types[L"uint"].convertible.insert(&types[L"int"]);
+
+                        // Primitive operators
+                        types[L"float"].addOperator(&types[L"float"], L"+", {{L"other", &types[L"float"]}});
+                        types[L"float"].addOperator(&types[L"float"], L"-", {{L"other", &types[L"float"]}});
+                        types[L"float"].addOperator(&types[L"float"], L"*", {{L"other", &types[L"float"]}});
+                        types[L"float"].addOperator(&types[L"float"], L"/", {{L"other", &types[L"float"]}});
+                        types[L"float"].addOperator(&types[L"bool"], L"==", {{L"other", &types[L"float"]}});
+                        types[L"float"].addOperator(&types[L"bool"], L"!=", {{L"other", &types[L"float"]}});
+                        types[L"float"].addOperator(&types[L"bool"], L"<", {{L"other", &types[L"float"]}});
+                        types[L"float"].addOperator(&types[L"bool"], L">", {{L"other", &types[L"float"]}});
+                        types[L"float"].addOperator(&types[L"bool"], L"<=", {{L"other", &types[L"float"]}});
+                        types[L"float"].addOperator(&types[L"bool"], L">=", {{L"other", &types[L"float"]}});
+
+                        types[L"int"].addOperator(&types[L"int"], L"+", {{L"other", &types[L"int"]}});
+                        types[L"int"].addOperator(&types[L"int"], L"-", {{L"other", &types[L"int"]}});
+                        types[L"int"].addOperator(&types[L"int"], L"*", {{L"other", &types[L"int"]}});
+                        types[L"int"].addOperator(&types[L"int"], L"/", {{L"other", &types[L"int"]}});
+                        types[L"int"].addOperator(&types[L"bool"], L"==", {{L"other", &types[L"int"]}});
+                        types[L"int"].addOperator(&types[L"bool"], L"!=", {{L"other", &types[L"int"]}});
+                        types[L"int"].addOperator(&types[L"bool"], L"<", {{L"other", &types[L"int"]}});
+                        types[L"int"].addOperator(&types[L"bool"], L">", {{L"other", &types[L"int"]}});
+                        types[L"int"].addOperator(&types[L"bool"], L"<=", {{L"other", &types[L"int"]}});
+                        types[L"int"].addOperator(&types[L"bool"], L">=", {{L"other", &types[L"int"]}});
+
+                        types[L"uint"].addOperator(&types[L"uint"], L"+", {{L"other", &types[L"uint"]}});
+                        types[L"uint"].addOperator(&types[L"uint"], L"-", {{L"other", &types[L"uint"]}});
+                        types[L"uint"].addOperator(&types[L"uint"], L"*", {{L"other", &types[L"uint"]}});
+                        types[L"uint"].addOperator(&types[L"uint"], L"/", {{L"other", &types[L"uint"]}});
+                        types[L"uint"].addOperator(&types[L"bool"], L"==", {{L"other", &types[L"uint"]}});
+                        types[L"uint"].addOperator(&types[L"bool"], L"!=", {{L"other", &types[L"uint"]}});
+                        types[L"uint"].addOperator(&types[L"bool"], L"<", {{L"other", &types[L"uint"]}});
+                        types[L"uint"].addOperator(&types[L"bool"], L">", {{L"other", &types[L"uint"]}});
+                        types[L"uint"].addOperator(&types[L"bool"], L"<=", {{L"other", &types[L"uint"]}});
+                        types[L"uint"].addOperator(&types[L"bool"], L">=", {{L"other", &types[L"uint"]}});
 			types[L"Vector2Int"].convertible.insert(&types[L"Vector2"]);
 			types[L"Vector2UInt"].convertible.insert(&types[L"Vector2"]);
 			types[L"Vector2"].convertible.insert(&types[L"Vector2Int"]);


### PR DESCRIPTION
## Summary
- register primitive arithmetic and comparison operators for `float`, `int`, and `uint`
- update binary expression evaluation to return `bool` for comparison and logical operators

## Testing
- `cmake -S . -B build` *(fails: Could NOT find GLEW)*

------
https://chatgpt.com/codex/tasks/task_e_687bf62b593883258015d3ca949ef904