### PR TITLE
Add return type validation in analyzer

### DIFF
--- a/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
@@ -48,6 +48,7 @@ namespace spk::Lumina
         std::vector<std::unordered_map<std::wstring, Variable>> _scopes;
         ShaderData _shaderData;
         std::vector<NamespaceSymbol*> _namespaceStack;
+        std::vector<const TypeSymbol*> _returnTypeStack;
         std::unordered_set<std::wstring> _namespaceNames;
         std::unordered_map<ASTNode::Kind, AnalyzeFn> _dispatch;
 


### PR DESCRIPTION
## Summary
- track expected return types when analyzing functions
- validate `return` statements against the expected type

## Testing
- `cmake --preset test` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_687c04109b78832598a26be2b64e9726