### PR TITLE
Enable swizzle access for vector and color types

### DIFF
--- a/src/structure/graphics/lumina/compiler/spk_analyzer.cpp
+++ b/src/structure/graphics/lumina/compiler/spk_analyzer.cpp
@@ -681,14 +681,15 @@ namespace spk::Lumina
 		(void)_evaluate(p_node);
 	}
 
-	void Analyzer::_analyzeMemberAccess(const ASTNode *p_node)
-	{
-		const auto *n = static_cast<const MemberAccessNode *>(p_node);
-		if (n->object)
-		{
-			(void)_evaluate(n->object.get());
-		}
-	}
+        void Analyzer::_analyzeMemberAccess(const ASTNode *p_node)
+        {
+                const auto *n = static_cast<const MemberAccessNode *>(p_node);
+                if (n->object)
+                {
+                        (void)_evaluate(n->object.get());
+                }
+                (void)_evaluate(p_node);
+        }
 
 	void Analyzer::_analyzeVariableReference(const ASTNode *)
 	{
@@ -1242,18 +1243,83 @@ namespace spk::Lumina
 		{
 			const MemberAccessNode *mem = static_cast<const MemberAccessNode *>(p_node);
 			std::wstring baseType = _evaluate(mem->object.get());
-			TypeSymbol *ts = _findType(baseType);
-			if (ts)
-			{
-				auto it = std::find_if(
-					ts->members.begin(), ts->members.end(), [&](const Variable &p_variable) { return p_variable.name == mem->member.lexeme; });
-				if (it != ts->members.end())
-				{
-					return it->type ? it->type->name : L"void";
-				}
-			}
-			return L"void";
-		}
+                        TypeSymbol *ts = _findType(baseType);
+                        if (ts)
+                        {
+                                auto it = std::find_if(
+                                        ts->members.begin(), ts->members.end(),
+                                        [&](const Variable &p_variable) { return p_variable.name == mem->member.lexeme; });
+                                if (it != ts->members.end())
+                                {
+                                        return it->type ? it->type->name : L"void";
+                                }
+
+                                int vectorSize = 0;
+                                if (baseType.rfind(L"Vector2", 0) == 0)
+                                        vectorSize = 2;
+                                else if (baseType.rfind(L"Vector3", 0) == 0)
+                                        vectorSize = 3;
+                                else if (baseType.rfind(L"Vector4", 0) == 0 || baseType == L"Color")
+                                        vectorSize = 4;
+
+                                if (vectorSize > 0)
+                                {
+                                        const std::wstring &member = mem->member.lexeme;
+                                        auto swizzleIndex = [](wchar_t c) -> int
+                                        {
+                                                switch (c)
+                                                {
+                                                case L'x':
+                                                case L'r':
+                                                        return 0;
+                                                case L'y':
+                                                case L'g':
+                                                        return 1;
+                                                case L'z':
+                                                case L'b':
+                                                        return 2;
+                                                case L'w':
+                                                case L'a':
+                                                        return 3;
+                                                default:
+                                                        return -1;
+                                                }
+                                        };
+
+                                        bool valid = !member.empty() && member.size() <= 4;
+                                        if (valid)
+                                        {
+                                                for (wchar_t ch : member)
+                                                {
+                                                        int idx = swizzleIndex(ch);
+                                                        if (idx < 0 || idx >= vectorSize)
+                                                        {
+                                                                valid = false;
+                                                                break;
+                                                        }
+                                                }
+                                        }
+
+                                        if (valid)
+                                        {
+                                                switch (member.size())
+                                                {
+                                                case 1:
+                                                        return L"float";
+                                                case 2:
+                                                        return L"Vector2";
+                                                case 3:
+                                                        return L"Vector3";
+                                                case 4:
+                                                        return L"Vector4";
+                                                default:
+                                                        break;
+                                                }
+                                        }
+                                }
+                        }
+                        return L"void";
+                }
 		case ASTNode::Kind::BinaryExpression:
 		{
 			const BinaryExpressionNode *bin = static_cast<const BinaryExpressionNode *>(p_node);


### PR DESCRIPTION
## Summary
- support GLSL style swizzling on Vector2/3/4 and Color
- validate member expressions with `_evaluate` in member access analysis

## Testing
- `cmake -B build -DENABLE_TESTS=ON` *(fails: GTest::gmock not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0a2baa1483259f75d07d2a2a76ab