### PR TITLE
Fix swizzle parsing after parentheses

### DIFF
--- a/include/structure/graphics/lumina/compiler/spk_lexer.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_lexer.hpp
@@ -48,8 +48,9 @@ namespace spk::Lumina
 		std::unique_ptr<ASTNode> parseDiscard();
 		std::unique_ptr<ASTNode> parseVariableDeclaration();
 		std::unique_ptr<ASTNode> parseExpression();
-		std::unique_ptr<ASTNode> parseUnary();
-		std::unique_ptr<ASTNode> parsePrimary();
+                std::unique_ptr<ASTNode> parseUnary();
+                std::unique_ptr<ASTNode> parsePostfix(std::unique_ptr<ASTNode> p_node);
+                std::unique_ptr<ASTNode> parsePrimary();
 		std::unique_ptr<ASTNode> parseBinaryRHS(int p_precedence, std::unique_ptr<ASTNode> p_left);
 		std::unique_ptr<ASTNode> parseFunction(ASTNode::Kind p_kind);
 		std::unique_ptr<ASTNode> parseOperator();


### PR DESCRIPTION
## Summary
- support postfix parsing after parenthesized expressions
- expose `parsePostfix` helper in lexer

## Testing
- `cmake --preset release` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_687cb9e2ffd48325803acf9d5faf3d74