### PR TITLE
Improve analyzer error message layout

### DIFF
--- a/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
@@ -16,9 +16,15 @@ namespace spk::Lumina
     class AnalyzerException : public std::runtime_error
     {
     public:
-        AnalyzerException(const std::wstring& p_msg, const Location& p_location, const SourceManager& p_sourceManager);
+        AnalyzerException(const std::wstring& p_msg,
+                           const Location& p_location,
+                           const SourceManager& p_sourceManager,
+                           const std::wstring& p_details = L"");
     private:
-        static std::wstring compose(const std::wstring& p_msg, const Location& p_location, const SourceManager& p_sourceManager);
+        static std::wstring compose(const std::wstring& p_msg,
+                                    const Location& p_location,
+                                    const SourceManager& p_sourceManager,
+                                    const std::wstring& p_details);
     };
 
     class Analyzer


### PR DESCRIPTION
## Summary
- add optional details parameter to `AnalyzerException`
- format `AnalyzerException` output to include details after the underline
- list available function signatures as bullet lines
- adjust overload resolution error handling to pass details

## Testing
- `cmake --preset debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_687cc473e6988325808b93e656ea606c