### PR TITLE
Fix global scope for uniform blocks

### DIFF
--- a/src/structure/graphics/lumina/compiler/spk_analyzer.cpp
+++ b/src/structure/graphics/lumina/compiler/spk_analyzer.cpp
@@ -360,12 +360,23 @@ namespace spk::Lumina
 					_analyze(c.get());
 				}
 			}
-			_popScope();
-			_popContainer();
-		}
-		else if (p_node->kind == ASTNode::Kind::ConstantBlock)
-		{
-			const auto *n = static_cast<const ConstantBlockNode *>(p_node);
+                        _popScope();
+                        _popContainer();
+                        if (_scopes.empty())
+                        {
+                                _pushScope();
+                        }
+                        {
+                                Variable var;
+                                var.name = n->name.lexeme;
+                                var.type = _findType(n->name.lexeme);
+                                auto &global = _scopes.front();
+                                global[var.name] = var;
+                        }
+                }
+                else if (p_node->kind == ASTNode::Kind::ConstantBlock)
+                {
+                        const auto *n = static_cast<const ConstantBlockNode *>(p_node);
 			{
 				_namespaceStack.back()->addType(n->name.lexeme, TypeSymbol::Role::Constant);
 			}
@@ -393,9 +404,20 @@ namespace spk::Lumina
 					_analyze(c.get());
 				}
 			}
-			_popScope();
-			_popContainer();
-		}
+                        _popScope();
+                        _popContainer();
+                        if (_scopes.empty())
+                        {
+                                _pushScope();
+                        }
+                        {
+                                Variable var;
+                                var.name = n->name.lexeme;
+                                var.type = _findType(n->name.lexeme);
+                                auto &global = _scopes.front();
+                                global[var.name] = var;
+                        }
+                }
 	}
 
 	void Analyzer::_analyzeTexture(const ASTNode *p_node)
@@ -1273,7 +1295,7 @@ namespace spk::Lumina
 					return iter->second.type ? iter->second.type->name : L"void";
 				}
 			}
-			throw AnalyzerException(L"Undefined variable " + ref->name.lexeme + L" - " + DEBUG_INFO(), ref->location, _sourceManager);
+                        throw AnalyzerException(L"Undefined variable " + ref->name.lexeme + L" - " + DEBUG_INFO(), ref->location, _sourceManager, L"", ref->name.lexeme.size());
 		}
 		case ASTNode::Kind::MemberAccess:
 		{


### PR DESCRIPTION
## Summary
- highlight entire variable name for undefined variable errors
- treat `AttributeBlock` and `ConstantBlock` declarations as global variables so they can be referenced elsewhere

## Testing
- `cmake -DENABLE_TESTS=OFF -DENABLE_PLAYGROUND=OFF ..` *(fails: Could NOT find GLEW)*

------
https://chatgpt.com/codex/tasks/task_e_687e164d9f148325a65ddba1c844d49d