### PR TITLE
Fix analyzer method lookup

### DIFF
--- a/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
+++ b/include/structure/graphics/lumina/compiler/spk_analyzer.hpp
@@ -70,8 +70,9 @@ namespace spk::Lumina
         TypeSymbol* _findType(const std::wstring& p_name) const;
         const NamespaceSymbol* _findNamespace(const std::wstring& p_name) const;
         std::wstring _conversionInfo(const std::wstring& p_from) const;
-	std::wstring _availableSignatures(const std::vector<FunctionSymbol>& p_funcs) const;
+        std::wstring _availableSignatures(const std::vector<FunctionSymbol>& p_funcs) const;
         std::wstring _extractCalleeName(const ASTNode* p_node) const;
+        Location _extractCalleeLocation(const ASTNode* p_node) const;
         std::vector<Variable> _parseParameters(const std::vector<Token>& p_header) const;
         std::vector<FunctionSymbol> _findFunctions(const std::wstring& p_name) const;
         bool _canConvert(const std::wstring& from, const std::wstring& to) const;

--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -34,7 +34,7 @@ ConstantBlock myConstants
 	Matrix4x4 constant1;
 	Color constant2;
 
-	int methodName(Vector2Int param1, float param2)
+	int methodName2(Vector2Int param1, float param2)
 	{
 		return 10;
 	}
@@ -55,9 +55,14 @@ Vector2 someFunction2(int a, int b, int c)
 return (Vector2().xy);
 }
 
-Vector2 someFunction3(int a, int b)
+Vector2 someFunction4(int a, int b)
 {
-return Vector2(0, a - b);
+return (Vector2().xy);
+}
+
+int someFunction3(int a, int b)
+{
+return a - b;
 }
 
 FragmentPass()
@@ -68,7 +73,7 @@ FragmentPass()
 	}
 
 	int value = someFunction1();
-	Vector2 value2 = someFunction2(1, value, someFunction3(1, 2));
+	Vector2 value2 = someFunction2(1, myConstants.methodName2(someFunction4(0, 1), 1), someFunction3(1, 2));
 
 	pixelColor = fragmentColor;
 }

--- a/src/structure/graphics/lumina/compiler/spk_analyzer.cpp
+++ b/src/structure/graphics/lumina/compiler/spk_analyzer.cpp
@@ -23,7 +23,6 @@ namespace spk::Lumina
 	{
 		const std::wstring &srcLine = p_sourceManager.getSourceLine(p_location);
 
-		const size_t tabWidth = 4;
 		std::wstring underline;
 
 		underline.reserve(p_location.column + p_markerLength);
@@ -360,23 +359,23 @@ namespace spk::Lumina
 					_analyze(c.get());
 				}
 			}
-                        _popScope();
-                        _popContainer();
-                        if (_scopes.empty())
-                        {
-                                _pushScope();
-                        }
-                        {
-                                Variable var;
-                                var.name = n->name.lexeme;
-                                var.type = _findType(n->name.lexeme);
-                                auto &global = _scopes.front();
-                                global[var.name] = var;
-                        }
-                }
-                else if (p_node->kind == ASTNode::Kind::ConstantBlock)
-                {
-                        const auto *n = static_cast<const ConstantBlockNode *>(p_node);
+			_popScope();
+			_popContainer();
+			if (_scopes.empty())
+			{
+				_pushScope();
+			}
+			{
+				Variable var;
+				var.name = n->name.lexeme;
+				var.type = _findType(n->name.lexeme);
+				auto &global = _scopes.front();
+				global[var.name] = var;
+			}
+		}
+		else if (p_node->kind == ASTNode::Kind::ConstantBlock)
+		{
+			const auto *n = static_cast<const ConstantBlockNode *>(p_node);
 			{
 				_namespaceStack.back()->addType(n->name.lexeme, TypeSymbol::Role::Constant);
 			}
@@ -404,20 +403,20 @@ namespace spk::Lumina
 					_analyze(c.get());
 				}
 			}
-                        _popScope();
-                        _popContainer();
-                        if (_scopes.empty())
-                        {
-                                _pushScope();
-                        }
-                        {
-                                Variable var;
-                                var.name = n->name.lexeme;
-                                var.type = _findType(n->name.lexeme);
-                                auto &global = _scopes.front();
-                                global[var.name] = var;
-                        }
-                }
+			_popScope();
+			_popContainer();
+			if (_scopes.empty())
+			{
+				_pushScope();
+			}
+			{
+				Variable var;
+				var.name = n->name.lexeme;
+				var.type = _findType(n->name.lexeme);
+				auto &global = _scopes.front();
+				global[var.name] = var;
+			}
+		}
 	}
 
 	void Analyzer::_analyzeTexture(const ASTNode *p_node)
@@ -523,27 +522,27 @@ namespace spk::Lumina
 				}
 			}
 		}
-               vec.push_back(sym);
-               _namespaceStack.back()->functions.push_back(sym);
-               if (!_containerStack.empty())
-               {
-                       TypeSymbol *tSym = _findType(_containerStack.back());
-                       if (tSym)
-                       {
-                               if (p_node->kind == ASTNode::Kind::Constructor)
-                               {
-                                       tSym->constructors.push_back(sym);
-                               }
-                               else if (p_node->kind == ASTNode::Kind::Operator)
-                               {
-                                       tSym->operators[name].push_back(sym);
-                               }
-                               else
-                               {
-                                       tSym->methods.push_back(sym);
-                               }
-                       }
-               }
+		vec.push_back(sym);
+		_namespaceStack.back()->functions.push_back(sym);
+		if (!_containerStack.empty())
+		{
+			TypeSymbol *tSym = _findType(_containerStack.back());
+			if (tSym)
+			{
+				if (p_node->kind == ASTNode::Kind::Constructor)
+				{
+					tSym->constructors.push_back(sym);
+				}
+				else if (p_node->kind == ASTNode::Kind::Operator)
+				{
+					tSym->operators[name].push_back(sym);
+				}
+				else
+				{
+					tSym->methods.push_back(sym);
+				}
+			}
+		}
 	}
 
 	void Analyzer::_analyzeVariableDeclaration(const ASTNode *p_node)
@@ -1030,8 +1029,8 @@ namespace spk::Lumina
 		return nullptr;
 	}
 
-std::wstring Analyzer::_extractCalleeName(const ASTNode *p_node) const
-{
+	std::wstring Analyzer::_extractCalleeName(const ASTNode *p_node) const
+	{
 		if (!p_node)
 		{
 			return {};
@@ -1145,51 +1144,51 @@ std::wstring Analyzer::_extractCalleeName(const ASTNode *p_node) const
 				}
 			}
 
-                        if (functions.empty())
-                        {
-                                typePointer = _findType(prefix);
-                                if (typePointer)
-                                {
-                                        if (target == prefix)
-                                        {
-                                                functions = typePointer->constructors;
-                                                constructor = true;
-                                        }
-                                        auto opIt = typePointer->operators.find(target);
-                                        if (opIt != typePointer->operators.end())
-                                        {
-                                                functions.insert(functions.end(), opIt->second.begin(), opIt->second.end());
-                                        }
-                                        for (const auto &m : typePointer->methods)
-                                        {
-                                                if (m.name == target)
-                                                {
-                                                        functions.push_back(m);
-                                                }
-                                        }
-                                }
-                        }
+			if (functions.empty())
+			{
+				typePointer = _findType(prefix);
+				if (typePointer)
+				{
+					if (target == prefix)
+					{
+						functions = typePointer->constructors;
+						constructor = true;
+					}
+					auto opIt = typePointer->operators.find(target);
+					if (opIt != typePointer->operators.end())
+					{
+						functions.insert(functions.end(), opIt->second.begin(), opIt->second.end());
+					}
+					for (const auto &m : typePointer->methods)
+					{
+						if (m.name == target)
+						{
+							functions.push_back(m);
+						}
+					}
+				}
+			}
 
-                        if (functions.empty() && objectNode)
-                        {
-                                std::wstring objType = _evaluate(objectNode);
-                                typePointer = _findType(objType);
-                                if (typePointer)
-                                {
-                                        auto opIt = typePointer->operators.find(target);
-                                        if (opIt != typePointer->operators.end())
-                                        {
-                                                functions = opIt->second;
-                                        }
-                                        for (const auto &m : typePointer->methods)
-                                        {
-                                                if (m.name == target)
-                                                {
-                                                        functions.push_back(m);
-                                                }
-                                        }
-                                }
-                        }
+			if (functions.empty() && objectNode)
+			{
+				std::wstring objType = _evaluate(objectNode);
+				typePointer = _findType(objType);
+				if (typePointer)
+				{
+					auto opIt = typePointer->operators.find(target);
+					if (opIt != typePointer->operators.end())
+					{
+						functions = opIt->second;
+					}
+					for (const auto &m : typePointer->methods)
+					{
+						if (m.name == target)
+						{
+							functions.push_back(m);
+						}
+					}
+				}
+			}
 		}
 		else
 		{
@@ -1207,50 +1206,50 @@ std::wstring Analyzer::_extractCalleeName(const ASTNode *p_node) const
 
 		if (functions.empty())
 		{
-			throw AnalyzerException(L"Unknown function " + p_name + L" - " + DEBUG_INFO(), p_loc, _sourceManager, L"", p_name.size());
+			throw AnalyzerException(L"Unknown function " + p_name + L" - " + DEBUG_INFO(), objectNode->location, _sourceManager, L"", p_name.size());
 		}
 
-                std::vector<const FunctionSymbol *> matches;
-                for (const auto &function : functions)
-                {
-                        if (function.parameters.size() != p_argTypes.size())
-                        {
-                                continue;
-                        }
-                        bool match = true;
-                        for (size_t i = 0; i < p_argTypes.size(); ++i)
-                        {
-                                std::wstring paramType = function.parameters[i].type ? function.parameters[i].type->name : L"void";
-                                if (!_canConvert(p_argTypes[i], paramType))
-                                {
-                                        match = false;
-                                        break;
-                                }
-                        }
-                        if (match)
-                        {
-                                matches.push_back(&function);
-                        }
-                }
+		std::vector<const FunctionSymbol *> matches;
+		for (const auto &function : functions)
+		{
+			if (function.parameters.size() != p_argTypes.size())
+			{
+				continue;
+			}
+			bool match = true;
+			for (size_t i = 0; i < p_argTypes.size(); ++i)
+			{
+				std::wstring paramType = function.parameters[i].type ? function.parameters[i].type->name : L"void";
+				if (!_canConvert(p_argTypes[i], paramType))
+				{
+					match = false;
+					break;
+				}
+			}
+			if (match)
+			{
+				matches.push_back(&function);
+			}
+		}
 
-                if (matches.size() == 1)
-                {
-                        const FunctionSymbol *function = matches.front();
-                        return constructor ? (typePointer ? typePointer->name : L"void") : (function->returnType ? function->returnType->name : L"void");
-                }
+		if (matches.size() == 1)
+		{
+			const FunctionSymbol *function = matches.front();
+			return constructor ? (typePointer ? typePointer->name : L"void") : (function->returnType ? function->returnType->name : L"void");
+		}
 
-                if (matches.size() > 1)
-                {
-                        std::wstring msg = L"Can't decide which function " + p_name + L" to call";
-                        std::wstring avail = _availableSignatures(functions);
-                        std::wstring details;
-                        if (!avail.empty())
-                        {
-                                details = L"Available :\n" + avail;
-                        }
-                        msg += L" - " + DEBUG_INFO();
-                        throw AnalyzerException(msg, p_loc, _sourceManager, details, p_name.size());
-                }
+		if (matches.size() > 1)
+		{
+			std::wstring msg = L"Can't decide which function " + p_name + L" to call";
+			std::wstring avail = _availableSignatures(functions);
+			std::wstring details;
+			if (!avail.empty())
+			{
+				details = L"Available :\n" + avail;
+			}
+			msg += L" - " + DEBUG_INFO();
+			throw AnalyzerException(msg, p_loc, _sourceManager, details, p_name.size());
+		}
 
 		if (constructor)
 		{
@@ -1313,7 +1312,8 @@ std::wstring Analyzer::_extractCalleeName(const ASTNode *p_node) const
 					return iter->second.type ? iter->second.type->name : L"void";
 				}
 			}
-                        throw AnalyzerException(L"Undefined variable " + ref->name.lexeme + L" - " + DEBUG_INFO(), ref->location, _sourceManager, L"", ref->name.lexeme.size());
+			throw AnalyzerException(
+				L"Undefined variable " + ref->name.lexeme + L" - " + DEBUG_INFO(), ref->location, _sourceManager, L"", ref->name.lexeme.size());
 		}
 		case ASTNode::Kind::MemberAccess:
 		{
@@ -1467,8 +1467,8 @@ std::wstring Analyzer::_extractCalleeName(const ASTNode *p_node) const
 				argTypes.push_back(_evaluate(arg.get()));
 			}
 
-                        return _resolveCall(call->callee.get(), name, argTypes, _extractCalleeLocation(call->callee.get()));
-                }
+			return _resolveCall(call->callee.get(), name, argTypes, _extractCalleeLocation(call->callee.get()));
+		}
 		case ASTNode::Kind::UnaryExpression:
 		{
 			const UnaryExpressionNode *un = static_cast<const UnaryExpressionNode *>(p_node);
@@ -1489,32 +1489,31 @@ std::wstring Analyzer::_extractCalleeName(const ASTNode *p_node) const
 		}
 	}
 
+	const ShaderData &Analyzer::getData() const
+	{
+		return _shaderData;
+	}
 
-        const ShaderData &Analyzer::getData() const
-        {
-                return _shaderData;
-        }
-
-        Location Analyzer::_extractCalleeLocation(const ASTNode *p_node) const
-        {
-                if (!p_node)
-                {
-                        return {};
-                }
-                switch (p_node->kind)
-                {
-                case ASTNode::Kind::VariableReference:
-                {
-                        const auto *n = static_cast<const VariableReferenceNode *>(p_node);
-                        return n->name.location;
-                }
-                case ASTNode::Kind::MemberAccess:
-                {
-                        const auto *m = static_cast<const MemberAccessNode *>(p_node);
-                        return m->member.location;
-                }
-                default:
-                        return p_node->location;
-                }
-        }
+	Location Analyzer::_extractCalleeLocation(const ASTNode *p_node) const
+	{
+		if (!p_node)
+		{
+			return {};
+		}
+		switch (p_node->kind)
+		{
+		case ASTNode::Kind::VariableReference:
+		{
+			const auto *n = static_cast<const VariableReferenceNode *>(p_node);
+			return n->name.location;
+		}
+		case ASTNode::Kind::MemberAccess:
+		{
+			const auto *m = static_cast<const MemberAccessNode *>(p_node);
+			return m->member.location;
+		}
+		default:
+			return p_node->location;
+		}
+	}
 }

--- a/src/structure/graphics/lumina/compiler/spk_analyzer.cpp
+++ b/src/structure/graphics/lumina/compiler/spk_analyzer.cpp
@@ -1030,8 +1030,8 @@ namespace spk::Lumina
 		return nullptr;
 	}
 
-	std::wstring Analyzer::_extractCalleeName(const ASTNode *p_node) const
-	{
+std::wstring Analyzer::_extractCalleeName(const ASTNode *p_node) const
+{
 		if (!p_node)
 		{
 			return {};
@@ -1467,8 +1467,8 @@ namespace spk::Lumina
 				argTypes.push_back(_evaluate(arg.get()));
 			}
 
-			return _resolveCall(call->callee.get(), name, argTypes, p_node->location);
-		}
+                        return _resolveCall(call->callee.get(), name, argTypes, _extractCalleeLocation(call->callee.get()));
+                }
 		case ASTNode::Kind::UnaryExpression:
 		{
 			const UnaryExpressionNode *un = static_cast<const UnaryExpressionNode *>(p_node);
@@ -1489,8 +1489,32 @@ namespace spk::Lumina
 		}
 	}
 
-	const ShaderData &Analyzer::getData() const
-	{
-		return _shaderData;
-	}
+
+        const ShaderData &Analyzer::getData() const
+        {
+                return _shaderData;
+        }
+
+        Location Analyzer::_extractCalleeLocation(const ASTNode *p_node) const
+        {
+                if (!p_node)
+                {
+                        return {};
+                }
+                switch (p_node->kind)
+                {
+                case ASTNode::Kind::VariableReference:
+                {
+                        const auto *n = static_cast<const VariableReferenceNode *>(p_node);
+                        return n->name.location;
+                }
+                case ASTNode::Kind::MemberAccess:
+                {
+                        const auto *m = static_cast<const MemberAccessNode *>(p_node);
+                        return m->member.location;
+                }
+                default:
+                        return p_node->location;
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- support methods declared in containers by adding them to `TypeSymbol`
- resolve member function calls using container methods

## Testing
- `cmake --preset test-debug` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_687e18d65c1c832597dcdeb598e0a2dc