### PR TITLE
Add basic Linux window support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,15 @@ add_resources(
 	find_package(GLEW REQUIRED)
 	target_link_libraries(Sparkle PUBLIC GLEW::GLEW)
 	
-	find_package(OpenGL REQUIRED)
-	target_link_libraries(Sparkle PUBLIC OpenGL::GL)
-	
-	target_link_libraries(Sparkle PUBLIC dinput8 dxguid ws2_32)
+find_package(OpenGL REQUIRED)
+target_link_libraries(Sparkle PUBLIC OpenGL::GL)
+
+if (WIN32)
+    target_link_libraries(Sparkle PUBLIC dinput8 dxguid ws2_32)
+else()
+    find_package(X11 REQUIRED)
+    target_link_libraries(Sparkle PUBLIC X11::X11)
+endif()
 	
 	message("Include : ${SPARKLE_INCLUDE_DIR}")
 	

--- a/include/structure/system/device/spk_controller_input_thread.hpp
+++ b/include/structure/system/device/spk_controller_input_thread.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <winsock2.h>
-#include <ws2tcpip.h>
+#include "utils/spk_platform.hpp"
 
-#include <windows.h>
-
+#ifdef _WIN32
 #define DIRECTINPUT_VERSION 0x0800
 
 #include "structure/math/spk_vector2.hpp"
@@ -17,8 +15,8 @@
 
 namespace spk
 {
-	class ControllerInputThread
-	{
+class ControllerInputThread
+{
 		friend class ControllerModule;
 
 	private:
@@ -263,9 +261,18 @@ namespace spk
 			_worker.start();
 		}
 
-		void stop()
-		{
-			_worker.stop();
-		}
-	};
+               void stop()
+               {
+                       _worker.stop();
+               }
+       };
+#else
+       class ControllerInputThread
+       {
+       public:
+               void bind(::Window) {}
+               void start() {}
+               void stop() {}
+       };
+#endif
 }

--- a/include/structure/system/event/spk_event.hpp
+++ b/include/structure/system/event/spk_event.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <winsock2.h>
-#include <ws2tcpip.h>
-
-#include <Windows.h>
+#include "utils/spk_platform.hpp"
 
 #include "structure/spk_safe_pointer.hpp"
 #include "structure/system/device/spk_controller.hpp"
@@ -17,6 +14,7 @@
 
 #include "utils/spk_system_utils.hpp"
 
+#ifdef _WIN32
 static const UINT WM_UPDATE_REQUEST = RegisterWindowMessage("WM_UPDATE_REQUEST");
 static const UINT WM_PAINT_REQUEST = RegisterWindowMessage("WM_PAINT_REQUEST");
 static const UINT WM_RESIZE_REQUEST = RegisterWindowMessage("WM_RESIZE_REQUEST");
@@ -32,6 +30,48 @@ static const UINT WM_DIRECTIONAL_CROSS_MOTION = RegisterWindowMessage("WM_DIRECT
 static const UINT WM_DIRECTIONAL_CROSS_RESET = RegisterWindowMessage("WM_DIRECTIONAL_CROSS_RESET");
 static const UINT WM_CONTROLLER_BUTTON_PRESS = RegisterWindowMessage("WM_CONTROLLER_BUTTON_PRESS");
 static const UINT WM_CONTROLLER_BUTTON_RELEASE = RegisterWindowMessage("WM_CONTROLLER_BUTTON_RELEASE");
+#else
+static const UINT WM_UPDATE_REQUEST = 0x0401;
+static const UINT WM_PAINT_REQUEST = 0x0402;
+static const UINT WM_RESIZE_REQUEST = 0x0403;
+static const UINT WM_LEFT_JOYSTICK_MOTION = 0x0404;
+static const UINT WM_RIGHT_JOYSTICK_MOTION = 0x0405;
+static const UINT WM_LEFT_JOYSTICK_RESET = 0x0406;
+static const UINT WM_RIGHT_JOYSTICK_RESET = 0x0407;
+static const UINT WM_LEFT_TRIGGER_MOTION = 0x0408;
+static const UINT WM_RIGHT_TRIGGER_MOTION = 0x0409;
+static const UINT WM_LEFT_TRIGGER_RESET = 0x040A;
+static const UINT WM_RIGHT_TRIGGER_RESET = 0x040B;
+static const UINT WM_DIRECTIONAL_CROSS_MOTION = 0x040C;
+static const UINT WM_DIRECTIONAL_CROSS_RESET = 0x040D;
+static const UINT WM_CONTROLLER_BUTTON_PRESS = 0x040E;
+static const UINT WM_CONTROLLER_BUTTON_RELEASE = 0x040F;
+static const UINT WM_PAINT = 0x000F;
+static const UINT WM_KEYDOWN = 0x0100;
+static const UINT WM_KEYUP = 0x0101;
+static const UINT WM_CHAR = 0x0102;
+static const UINT WM_MOUSEMOVE = 0x0200;
+static const UINT WM_LBUTTONDOWN = 0x0201;
+static const UINT WM_LBUTTONUP = 0x0202;
+static const UINT WM_LBUTTONDBLCLK = 0x0203;
+static const UINT WM_RBUTTONDOWN = 0x0204;
+static const UINT WM_RBUTTONUP = 0x0205;
+static const UINT WM_RBUTTONDBLCLK = 0x0206;
+static const UINT WM_MBUTTONDOWN = 0x0207;
+static const UINT WM_MBUTTONUP = 0x0208;
+static const UINT WM_MBUTTONDBLCLK = 0x0209;
+static const UINT WM_MOUSEWHEEL = 0x020A;
+static const UINT WM_MOVE = 0x0003;
+static const UINT WM_SIZE = 0x0005;
+static const UINT WM_SETFOCUS = 0x0007;
+static const UINT WM_KILLFOCUS = 0x0008;
+static const UINT WM_CLOSE = 0x0010;
+static const UINT WM_QUIT = 0x0012;
+static const UINT WM_SETCURSOR = 0x0020;
+static const UINT WM_ENTERSIZEMOVE = 0x0231;
+static const UINT WM_EXITSIZEMOVE = 0x0232;
+static const UINT WM_TIMER = 0x0113;
+#endif
 
 namespace spk
 {

--- a/include/utils/spk_platform.hpp
+++ b/include/utils/spk_platform.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <Windows.h>
+#else
+#include <X11/Xlib.h>
+#include <X11/keysym.h>
+#include <X11/Xutil.h>
+#include <GL/glx.h>
+#include <cstdint>
+using UINT = unsigned int;
+using WPARAM = unsigned long;
+using LPARAM = long;
+using LRESULT = long;
+using UINT_PTR = unsigned long;
+
+#ifndef LOWORD
+#define LOWORD(l)   ((unsigned short)((l) & 0xFFFF))
+#endif
+#ifndef HIWORD
+#define HIWORD(l)   ((unsigned short)(((l) >> 16) & 0xFFFF))
+#endif
+#ifndef MAKELPARAM
+#define MAKELPARAM(l, h) ((LPARAM)(((unsigned short)(l)) | ((unsigned long)((unsigned short)(h))) << 16))
+#endif
+#ifndef GET_WHEEL_DELTA_WPARAM
+#define GET_WHEEL_DELTA_WPARAM(wParam) HIWORD(wParam)
+#endif
+#endif

--- a/src/structure/graphics/spk_window.cpp
+++ b/src/structure/graphics/spk_window.cpp
@@ -3,9 +3,13 @@
 #include "application/spk_graphical_application.hpp"
 
 #include <GL/glew.h>
+#ifdef _WIN32
 #include <GL/wglew.h>
 #include <gl/GL.h>
 #include <gl/GLU.h>
+#else
+#include <GL/glx.h>
+#endif
 
 #include "utils/spk_string_utils.hpp"
 
@@ -23,44 +27,48 @@ namespace spk
 		_onClosureCallback = p_onClosureCallback;
 	}
 
-	LRESULT CALLBACK Window::WindowProc(HWND p_hwnd, UINT p_uMsg, WPARAM p_wParam, LPARAM p_lParam)
-	{
-		Window *window = nullptr;
+#ifdef _WIN32
+       LRESULT CALLBACK Window::WindowProc(HWND p_hwnd, UINT p_uMsg, WPARAM p_wParam, LPARAM p_lParam)
+       {
+               Window *window = nullptr;
 
-		if (p_uMsg == WM_NCCREATE)
-		{
-			CREATESTRUCT *pCreate = reinterpret_cast<CREATESTRUCT *>(p_lParam);
-			window = reinterpret_cast<Window *>(pCreate->lpCreateParams);
-			SetWindowLongPtr(p_hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(window));
-		}
-		else
-		{
-			window = reinterpret_cast<Window *>(GetWindowLongPtr(p_hwnd, GWLP_USERDATA));
-		}
+               if (p_uMsg == WM_NCCREATE)
+               {
+                       CREATESTRUCT *pCreate = reinterpret_cast<CREATESTRUCT *>(p_lParam);
+                       window = reinterpret_cast<Window *>(pCreate->lpCreateParams);
+                       SetWindowLongPtr(p_hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(window));
+               }
+               else
+               {
+                       window = reinterpret_cast<Window *>(GetWindowLongPtr(p_hwnd, GWLP_USERDATA));
+               }
 
-		if (window != nullptr)
-		{
-			if (window->_receiveEvent(p_uMsg, p_wParam, p_lParam) == true)
-			{
-				return (TRUE);
-			}
-		}
+               if (window != nullptr)
+               {
+                       if (window->_receiveEvent(p_uMsg, p_wParam, p_lParam) == true)
+                       {
+                               return (TRUE);
+                       }
+               }
 
-		return DefWindowProc(p_hwnd, p_uMsg, p_wParam, p_lParam);
-	}
+               return DefWindowProc(p_hwnd, p_uMsg, p_wParam, p_lParam);
+       }
+#endif
 
 	bool Window::_receiveEvent(UINT p_uMsg, WPARAM p_wParam, LPARAM p_lParam)
 	{
-		if (p_uMsg == WM_SETCURSOR)
-		{
-			if (LOWORD(p_lParam) == HTCLIENT)
-			{
-				::SetCursor(_currentCursor);
-				return true;
-			}
+#ifdef _WIN32
+               if (p_uMsg == WM_SETCURSOR)
+               {
+                       if (LOWORD(p_lParam) == HTCLIENT)
+                       {
+                               ::SetCursor(_currentCursor);
+                               return true;
+                       }
 
-			return false;
-		}
+                       return false;
+               }
+#endif
 
 		if (_subscribedModules.contains(p_uMsg) == false)
 		{
@@ -70,62 +78,109 @@ namespace spk
 		return (true);
 	}
 
-	void Window::_createContext()
-	{
-		RECT adjustedRect = {static_cast<LONG>(0),
-							 static_cast<LONG>(0),
-							 static_cast<LONG>(_rootWidget->viewport().geometry().width),
-							 static_cast<LONG>(_rootWidget->viewport().geometry().height)};
-		if (!AdjustWindowRectEx(&adjustedRect, WS_OVERLAPPEDWINDOW, FALSE, 0))
-		{
-			GENERATE_ERROR("Failed to adjust window rect.");
-		}
+       void Window::_createContext()
+       {
+#ifdef _WIN32
+               RECT adjustedRect = {static_cast<LONG>(0),
+                                                        static_cast<LONG>(0),
+                                                        static_cast<LONG>(_rootWidget->viewport().geometry().width),
+                                                        static_cast<LONG>(_rootWidget->viewport().geometry().height)};
+               if (!AdjustWindowRectEx(&adjustedRect, WS_OVERLAPPEDWINDOW, FALSE, 0))
+               {
+                       GENERATE_ERROR("Failed to adjust window rect.");
+               }
 
-		std::string convertedTitle = spk::StringUtils::wstringToString(_title);
+               std::string convertedTitle = spk::StringUtils::wstringToString(_title);
 
-		_hwnd = CreateWindowEx(0,
-							   "SPKWindowClass",
-							   convertedTitle.c_str(),
-							   WS_OVERLAPPEDWINDOW,
-							   _rootWidget->viewport().geometry().x,
-							   _rootWidget->viewport().geometry().y,
-							   adjustedRect.right - adjustedRect.left,
-							   adjustedRect.bottom - adjustedRect.top,
-							   nullptr,
-							   nullptr,
-							   GetModuleHandle(nullptr),
-							   this);
+               _hwnd = CreateWindowEx(0,
+                                                          "SPKWindowClass",
+                                                          convertedTitle.c_str(),
+                                                          WS_OVERLAPPEDWINDOW,
+                                                          _rootWidget->viewport().geometry().x,
+                                                          _rootWidget->viewport().geometry().y,
+                                                          adjustedRect.right - adjustedRect.left,
+                                                          adjustedRect.bottom - adjustedRect.top,
+                                                          nullptr,
+                                                          nullptr,
+                                                          GetModuleHandle(nullptr),
+                                                          this);
 
-		if (!_hwnd)
-		{
-			GENERATE_ERROR("Failed to create window.");
-		}
+               if (!_hwnd)
+               {
+                       GENERATE_ERROR("Failed to create window.");
+               }
 
-		_cursors[L"Arrow"] = ::LoadCursor(nullptr, IDC_ARROW);
-		_cursors[L"TextEdit"] = ::LoadCursor(nullptr, IDC_IBEAM);
-		_cursors[L"Wait"] = ::LoadCursor(nullptr, IDC_WAIT);
-		_cursors[L"Cross"] = ::LoadCursor(nullptr, IDC_CROSS);
-		_cursors[L"AltCross"] = ::LoadCursor(nullptr, IDC_UPARROW);
-		_cursors[L"ResizeNWSE"] = ::LoadCursor(nullptr, IDC_SIZENWSE);
-		_cursors[L"ResizeNESW"] = ::LoadCursor(nullptr, IDC_SIZENESW);
-		_cursors[L"ResizeWE"] = ::LoadCursor(nullptr, IDC_SIZEWE);
-		_cursors[L"ResizeNS"] = ::LoadCursor(nullptr, IDC_SIZENS);
-		_cursors[L"Move"] = ::LoadCursor(nullptr, IDC_SIZEALL);
-		_cursors[L"No"] = ::LoadCursor(nullptr, IDC_NO);
-		_cursors[L"Hand"] = ::LoadCursor(nullptr, IDC_HAND);
-		_cursors[L"Working"] = ::LoadCursor(nullptr, IDC_APPSTARTING);
-		_cursors[L"Help"] = ::LoadCursor(nullptr, IDC_HELP);
+               _cursors[L"Arrow"] = ::LoadCursor(nullptr, IDC_ARROW);
+               _cursors[L"TextEdit"] = ::LoadCursor(nullptr, IDC_IBEAM);
+               _cursors[L"Wait"] = ::LoadCursor(nullptr, IDC_WAIT);
+               _cursors[L"Cross"] = ::LoadCursor(nullptr, IDC_CROSS);
+               _cursors[L"AltCross"] = ::LoadCursor(nullptr, IDC_UPARROW);
+               _cursors[L"ResizeNWSE"] = ::LoadCursor(nullptr, IDC_SIZENWSE);
+               _cursors[L"ResizeNESW"] = ::LoadCursor(nullptr, IDC_SIZENESW);
+               _cursors[L"ResizeWE"] = ::LoadCursor(nullptr, IDC_SIZEWE);
+               _cursors[L"ResizeNS"] = ::LoadCursor(nullptr, IDC_SIZENS);
+               _cursors[L"Move"] = ::LoadCursor(nullptr, IDC_SIZEALL);
+               _cursors[L"No"] = ::LoadCursor(nullptr, IDC_NO);
+               _cursors[L"Hand"] = ::LoadCursor(nullptr, IDC_HAND);
+               _cursors[L"Working"] = ::LoadCursor(nullptr, IDC_APPSTARTING);
+               _cursors[L"Help"] = ::LoadCursor(nullptr, IDC_HELP);
 
-		setUpdateTimer(1);
+               setUpdateTimer(1);
 
-		setCursor(L"Arrow");
+               setCursor(L"Arrow");
 
-		_controllerInputThread.bind(_hwnd);
-		_createOpenGLContext();
+               _controllerInputThread.bind(_hwnd);
+               _createOpenGLContext();
 
-		ShowWindow(_hwnd, SW_SHOW);
-		UpdateWindow(_hwnd);
-	}
+               ShowWindow(_hwnd, SW_SHOW);
+               UpdateWindow(_hwnd);
+#else
+               _display = XOpenDisplay(nullptr);
+               if (!_display)
+               {
+                       GENERATE_ERROR("Failed to open X display");
+               }
+               int screen = DefaultScreen(_display);
+               GLint att[] = {GLX_RGBA, GLX_DEPTH_SIZE, 24, GLX_DOUBLEBUFFER, None};
+               XVisualInfo* vi = glXChooseVisual(_display, screen, att);
+               if (!vi)
+               {
+                       GENERATE_ERROR("No appropriate visual found");
+               }
+               Colormap cmap = XCreateColormap(_display, RootWindow(_display, screen), vi->visual, AllocNone);
+               XSetWindowAttributes swa;
+               swa.colormap = cmap;
+               swa.event_mask = ExposureMask | KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask |
+                                 PointerMotionMask | StructureNotifyMask | FocusChangeMask;
+               _window = XCreateWindow(_display,
+                                      RootWindow(_display, screen),
+                                      _rootWidget->viewport().geometry().x,
+                                      _rootWidget->viewport().geometry().y,
+                                      _rootWidget->viewport().geometry().width,
+                                      _rootWidget->viewport().geometry().height,
+                                      0,
+                                      vi->depth,
+                                      InputOutput,
+                                      vi->visual,
+                                      CWColormap | CWEventMask,
+                                      &swa);
+
+               Atom wmDelete = XInternAtom(_display, "WM_DELETE_WINDOW", False);
+               XSetWMProtocols(_display, _window, &wmDelete, 1);
+
+               std::string convertedTitle = spk::StringUtils::wstringToString(_title);
+               XStoreName(_display, _window, convertedTitle.c_str());
+
+               _glxContext = glXCreateContext(_display, vi, NULL, GL_TRUE);
+               glXMakeCurrent(_display, _window, _glxContext);
+               glewInit();
+
+               _cursors[L"Arrow"] = XCreateFontCursor(_display, XC_left_ptr);
+               setCursor(L"Arrow");
+
+               XMapWindow(_display, _window);
+#endif
+       }
 
 	void Window::_handlePendingTimer()
 	{
@@ -212,10 +267,11 @@ namespace spk
 		_pendingTimerDeletions.push_back(p_id + 2);
 	}
 
-	void Window::_createOpenGLContext()
-	{
-		_hdc = GetDC(_hwnd);
-		PIXELFORMATDESCRIPTOR pfd = {sizeof(PIXELFORMATDESCRIPTOR),
+       void Window::_createOpenGLContext()
+       {
+#ifdef _WIN32
+               _hdc = GetDC(_hwnd);
+               PIXELFORMATDESCRIPTOR pfd = {sizeof(PIXELFORMATDESCRIPTOR),
 									 1,
 									 PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
 									 PFD_TYPE_RGBA,
@@ -332,26 +388,59 @@ namespace spk
 		glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 		glStencilMask(0xFF);
 
-		glEnable(GL_SCISSOR_TEST);
+               glEnable(GL_SCISSOR_TEST);
+               wglSwapIntervalEXT(0);
+#else
+               glewExperimental = GL_TRUE;
+               glewInit();
 
-		wglSwapIntervalEXT(0);
-	}
+               glEnable(GL_BLEND);
+               glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+               glEnable(GL_CULL_FACE);
+               glFrontFace(GL_CCW);
+               glEnable(GL_DEPTH_TEST);
+               glDepthMask(GL_TRUE);
+               glClearDepth(1.0f);
+               glDepthFunc(GL_LEQUAL);
+               glDisable(GL_STENCIL_TEST);
+               glStencilFunc(GL_ALWAYS, 0, 0xFF);
+               glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
+               glStencilMask(0xFF);
+               glEnable(GL_SCISSOR_TEST);
+#endif
+       }
 
-	void Window::_destroyOpenGLContext()
-	{
-		if (_hglrc)
-		{
-			wglMakeCurrent(nullptr, nullptr);
-			wglDeleteContext(_hglrc);
-			_hglrc = nullptr;
-		}
+       void Window::_destroyOpenGLContext()
+       {
+#ifdef _WIN32
+               if (_hglrc)
+               {
+                       wglMakeCurrent(nullptr, nullptr);
+                       wglDeleteContext(_hglrc);
+                       _hglrc = nullptr;
+               }
 
-		if (_hwnd && _hdc)
-		{
-			ReleaseDC(_hwnd, _hdc);
-			_hdc = nullptr;
-		}
-	}
+               if (_hwnd && _hdc)
+               {
+                       ReleaseDC(_hwnd, _hdc);
+                       _hdc = nullptr;
+               }
+#else
+               if (_glxContext)
+               {
+                       glXMakeCurrent(_display, None, nullptr);
+                       glXDestroyContext(_display, _glxContext);
+                       _glxContext = nullptr;
+               }
+
+               if (_display)
+               {
+                       XDestroyWindow(_display, _window);
+                       XCloseDisplay(_display);
+                       _display = nullptr;
+               }
+#endif
+       }
 
 	Window::Window(const std::wstring &p_title, const spk::Geometry2D &p_geometry) :
 		_rootWidget(std::make_unique<Widget>(p_title + L" - CentralWidget", nullptr)),
@@ -497,18 +586,24 @@ namespace spk
 		}
 	}
 
-	void Window::close()
-	{
-		_windowRendererThread.stop();
-		_windowUpdaterThread.stop();
-		_controllerInputThread.stop();
-
-		if (_hwnd)
-		{
-			DestroyWindow(_hwnd);
-			_hwnd = nullptr;
-		}
-		_destroyOpenGLContext();
+       void Window::close()
+       {
+               _windowRendererThread.stop();
+               _windowUpdaterThread.stop();
+               _controllerInputThread.stop();
+#ifdef _WIN32
+               if (_hwnd)
+               {
+                       DestroyWindow(_hwnd);
+                       _hwnd = nullptr;
+               }
+#else
+               if (_display)
+               {
+                       XDestroyWindow(_display, _window);
+               }
+#endif
+               _destroyOpenGLContext();
 
 		if (_onClosureCallback != nullptr)
 		{
@@ -544,42 +639,118 @@ namespace spk
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 	}
 
-	void Window::swap() const
-	{
-		SwapBuffers(_hdc);
-	}
+       void Window::swap() const
+       {
+#ifdef _WIN32
+               SwapBuffers(_hdc);
+#else
+               glXSwapBuffers(_display, _window);
+#endif
+       }
 
-	void Window::addCursor(const std::wstring &p_cursorName, const std::filesystem::path &p_cursorPath)
-	{
-		_cursors[p_cursorName] = LoadCursorFromFileW(p_cursorPath.c_str());
-	}
+       void Window::addCursor(const std::wstring &p_cursorName, const std::filesystem::path &p_cursorPath)
+       {
+#ifdef _WIN32
+               _cursors[p_cursorName] = LoadCursorFromFileW(p_cursorPath.c_str());
+#else
+               _cursors[p_cursorName] = XCreateFontCursor(_display, XC_left_ptr);
+#endif
+       }
 
-	void Window::setCursor(const std::wstring &p_cursorName)
-	{
-		if (_cursors.contains(p_cursorName) == false)
-		{
-			GENERATE_ERROR("Cursor [" + spk::StringUtils::wstringToString(p_cursorName) + "] not found.");
-		}
+       void Window::setCursor(const std::wstring &p_cursorName)
+       {
+               if (_cursors.contains(p_cursorName) == false)
+               {
+                       GENERATE_ERROR("Cursor [" + spk::StringUtils::wstringToString(p_cursorName) + "] not found.");
+               }
+#ifdef _WIN32
+               HCURSOR nextCursor = _cursors[p_cursorName];
+               if (_currentCursor == nextCursor)
+               {
+                       return;
+               }
+               _currentCursor = nextCursor;
+#else
+               Cursor nextCursor = _cursors[p_cursorName];
+               if (_currentCursor == nextCursor)
+               {
+                       return;
+               }
+               _currentCursor = nextCursor;
+               XDefineCursor(_display, _window, _currentCursor);
+#endif
+       }
 
-		HCURSOR nextCursor = _cursors[p_cursorName];
-		if (_currentCursor == nextCursor)
-		{
-			return;
-		}
-
-		_currentCursor = nextCursor;
-	}
-
-	void Window::pullEvents()
-	{
-		MSG msg;
-
-		while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
-		{
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-		}
-	}
+       void Window::pullEvents()
+       {
+#ifdef _WIN32
+               MSG msg;
+               while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
+               {
+                       TranslateMessage(&msg);
+                       DispatchMessage(&msg);
+               }
+#else
+               XEvent evt;
+               while (XPending(_display))
+               {
+                       XNextEvent(_display, &evt);
+                       switch (evt.type)
+                       {
+                       case Expose:
+                               _postedEvents.emplace_back(WM_PAINT_REQUEST, 0, 0);
+                               break;
+                       case ConfigureNotify:
+                               _postedEvents.emplace_back(WM_SIZE, 0, MAKELPARAM(evt.xconfigure.width, evt.xconfigure.height));
+                               break;
+                       case KeyPress:
+                               _postedEvents.emplace_back(WM_KEYDOWN, evt.xkey.keycode, 0);
+                               break;
+                       case KeyRelease:
+                               _postedEvents.emplace_back(WM_KEYUP, evt.xkey.keycode, 0);
+                               break;
+                       case ButtonPress:
+                               if (evt.xbutton.button == Button1)
+                                       _postedEvents.emplace_back(WM_LBUTTONDOWN, 0, 0);
+                               else if (evt.xbutton.button == Button3)
+                                       _postedEvents.emplace_back(WM_RBUTTONDOWN, 0, 0);
+                               else if (evt.xbutton.button == Button2)
+                                       _postedEvents.emplace_back(WM_MBUTTONDOWN, 0, 0);
+                               else if (evt.xbutton.button == 4)
+                                       _postedEvents.emplace_back(WM_MOUSEWHEEL, MAKEWPARAM(0, 120), 0);
+                               else if (evt.xbutton.button == 5)
+                                       _postedEvents.emplace_back(WM_MOUSEWHEEL, MAKEWPARAM(0, -120), 0);
+                               break;
+                       case ButtonRelease:
+                               if (evt.xbutton.button == Button1)
+                                       _postedEvents.emplace_back(WM_LBUTTONUP, 0, 0);
+                               else if (evt.xbutton.button == Button3)
+                                       _postedEvents.emplace_back(WM_RBUTTONUP, 0, 0);
+                               else if (evt.xbutton.button == Button2)
+                                       _postedEvents.emplace_back(WM_MBUTTONUP, 0, 0);
+                               break;
+                       case MotionNotify:
+                               _postedEvents.emplace_back(WM_MOUSEMOVE, 0, MAKELPARAM(evt.xmotion.x, evt.xmotion.y));
+                               break;
+                       case FocusIn:
+                               _postedEvents.emplace_back(WM_SETFOCUS, 0, 0);
+                               break;
+                       case FocusOut:
+                               _postedEvents.emplace_back(WM_KILLFOCUS, 0, 0);
+                               break;
+                       case ClientMessage:
+                               _postedEvents.emplace_back(WM_CLOSE, 0, 0);
+                               break;
+                       }
+               }
+               while (_postedEvents.empty() == false)
+               {
+                       auto e = _postedEvents.front();
+                       _postedEvents.pop_front();
+                       _receiveEvent(std::get<0>(e), std::get<1>(e), std::get<2>(e));
+               }
+#endif
+       }
 
 	void Window::bindModule(spk::IModule *p_module)
 	{
@@ -614,22 +785,34 @@ namespace spk
 		_isPaintRequestAllowed = true;
 	}
 
-	void Window::requestPaint() const
-	{
-		if (_isPaintRequestAllowed == true)
-		{
-			PostMessage(_hwnd, WM_PAINT_REQUEST, 0, 0);
-			_isPaintRequestAllowed = false;
-		}
-	}
+       void Window::requestPaint() const
+       {
+               if (_isPaintRequestAllowed == true)
+               {
+#ifdef _WIN32
+                       PostMessage(_hwnd, WM_PAINT_REQUEST, 0, 0);
+#else
+                       _postedEvents.emplace_back(WM_PAINT_REQUEST, 0, 0);
+#endif
+                       _isPaintRequestAllowed = false;
+               }
+       }
 
-	void Window::requestResize(const spk::Vector2Int& p_size) const
-	{
-		PostMessage(_hwnd, WM_RESIZE_REQUEST, static_cast<WPARAM>(p_size.x), static_cast<LPARAM>(p_size.y));
-	}
+       void Window::requestResize(const spk::Vector2Int& p_size) const
+       {
+#ifdef _WIN32
+               PostMessage(_hwnd, WM_RESIZE_REQUEST, static_cast<WPARAM>(p_size.x), static_cast<LPARAM>(p_size.y));
+#else
+               _postedEvents.emplace_back(WM_RESIZE_REQUEST, static_cast<WPARAM>(p_size.x), static_cast<LPARAM>(p_size.y));
+#endif
+       }
 
-	void Window::requestUpdate() const
-	{
-		PostMessage(_hwnd, WM_UPDATE_REQUEST, 0, 0);
-	}
+       void Window::requestUpdate() const
+       {
+#ifdef _WIN32
+               PostMessage(_hwnd, WM_UPDATE_REQUEST, 0, 0);
+#else
+               _postedEvents.emplace_back(WM_UPDATE_REQUEST, 0, 0);
+#endif
+       }
 }


### PR DESCRIPTION
## Summary
- introduce `spk_platform.hpp` to abstract Win32 types
- define platform independent message IDs
- add Linux fields to `Window`
- implement preliminary GLX window backend
- stub out controller input on non‑Windows
- link X11 on non‑Windows systems

## Testing
- `clang-format` *(failed: unknown key 'BeforeBlock')*
- `clang-tidy` *(failed: 'GL/glx.h' file not found)*
- `cmake --preset test-debug` *(failed: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_6883a07a5b4083259a95d8726683b46f