### PR TITLE
Add nested layout element helpers

### DIFF
--- a/include/widget/spk_grid_layout.hpp
+++ b/include/widget/spk_grid_layout.hpp
@@ -48,15 +48,15 @@ namespace spk
 
 			for (size_t r = 0; r < NbRows; ++r)
 			{
-				for (size_t c = 0; c < NbColumns; ++c)
-				{
-					Element *elt = _elements[r * NbColumns + c].get();
-					if (elt == nullptr || elt->widget() == nullptr)
-					{
-						continue;
-					}
+                                for (size_t c = 0; c < NbColumns; ++c)
+                                {
+                                        Element *elt = _elements[r * NbColumns + c].get();
+                                        if (elt == nullptr || (elt->widget() == nullptr && elt->layout() == nullptr))
+                                        {
+                                                continue;
+                                        }
 
-					const spk::Vector2Int req = elt->size();
+                                        const spk::Vector2Int req = elt->size();
 
 					switch (elt->sizePolicy())
 					{
@@ -66,19 +66,19 @@ namespace spk
 						rowHeight[r] = std::max(rowHeight[r], req.y);
 						break;
 					}
-					case SizePolicy::Minimum:
-					case SizePolicy::VerticalExtend:
-					{
-						spk::Vector2Int minSize = elt->widget()->minimalSize();
-						colWidth[c] = std::max(colWidth[c], minSize.x);
-						rowHeight[r] = std::max(rowHeight[r], minSize.y);
-						break;
-					}
-					case SizePolicy::Maximum:
-					{
-						spk::Vector2Int maxSize = elt->widget()->maximalSize();
-						colWidth[c] = std::min(colWidth[c], maxSize.x);
-						rowHeight[r] = std::min(rowHeight[r], maxSize.y);
+                                       case SizePolicy::Minimum:
+                                       case SizePolicy::VerticalExtend:
+                                       {
+                                               spk::Vector2Int minSize = elt->minimalSize();
+                                               colWidth[c] = std::max(colWidth[c], minSize.x);
+                                               rowHeight[r] = std::max(rowHeight[r], minSize.y);
+                                               break;
+                                       }
+                                       case SizePolicy::Maximum:
+                                       {
+                                               spk::Vector2Int maxSize = elt->maximalSize();
+                                               colWidth[c] = std::min(colWidth[c], maxSize.x);
+                                               rowHeight[r] = std::min(rowHeight[r], maxSize.y);
 						break;
 					}
 					case SizePolicy::Extend:
@@ -169,22 +169,51 @@ namespace spk
 				}
 			}
 
-			int y = p_geometry.anchor.y;
-			for (size_t r = 0; r < NbRows; ++r)
-			{
-				int x = p_geometry.anchor.x;
-				for (size_t c = 0; c < NbColumns; ++c)
-				{
-					Element *elt = _elements[r * NbColumns + c].get();
-					if (elt && elt->widget() != nullptr)
-					{
-						spk::Geometry2D cellGeom({x, y}, {colWidth[c], rowHeight[r]});
-						elt->widget()->setGeometry(cellGeom);
-					}
-					x += colWidth[c] + static_cast<int>(_elementPadding.x);
-				}
-				y += rowHeight[r] + static_cast<int>(_elementPadding.y);
-			}
-		}
-	};
+                        int y = p_geometry.anchor.y;
+                        for (size_t r = 0; r < NbRows; ++r)
+                        {
+                                int x = p_geometry.anchor.x;
+                                for (size_t c = 0; c < NbColumns; ++c)
+                                {
+                                        Element *elt = _elements[r * NbColumns + c].get();
+                                        if (elt && (elt->widget() != nullptr || elt->layout() != nullptr))
+                                        {
+                                                spk::Geometry2D cellGeom({x, y}, {colWidth[c], rowHeight[r]});
+                                                elt->setGeometry(cellGeom);
+                                        }
+                                        x += colWidth[c] + static_cast<int>(_elementPadding.x);
+                                }
+                                y += rowHeight[r] + static_cast<int>(_elementPadding.y);
+                        }
+                }
+
+                spk::Vector2UInt minimalSize() const
+                {
+                        std::array<uint32_t, NbColumns> colWidth{};
+                        std::array<uint32_t, NbRows> rowHeight{};
+
+                        for (size_t r = 0; r < NbRows; ++r)
+                        {
+                                for (size_t c = 0; c < NbColumns; ++c)
+                                {
+                                        Element* elt = _elements[r * NbColumns + c].get();
+                                        if (!elt || (elt->widget() == nullptr && elt->layout() == nullptr))
+                                                continue;
+
+                                        spk::Vector2UInt minSize = elt->minimalSize();
+
+                                        colWidth[c] = std::max(colWidth[c], minSize.x);
+                                        rowHeight[r] = std::max(rowHeight[r], minSize.y);
+                                }
+                        }
+
+                        uint32_t totalW = std::accumulate(colWidth.begin(), colWidth.end(), 0u);
+                        uint32_t totalH = std::accumulate(rowHeight.begin(), rowHeight.end(), 0u);
+
+                        totalW += static_cast<uint32_t>((NbColumns > 0 ? NbColumns - 1 : 0) * _elementPadding.x);
+                        totalH += static_cast<uint32_t>((NbRows > 0 ? NbRows - 1 : 0) * _elementPadding.y);
+
+                        return {totalW, totalH};
+                }
+        };
 }

--- a/include/widget/spk_layout.hpp
+++ b/include/widget/spk_layout.hpp
@@ -3,6 +3,7 @@
 #include "structure/spk_safe_pointer.hpp"
 
 #include "structure/math/spk_vector2.hpp"
+#include "structure/graphics/spk_geometry_2D.hpp"
 
 #include "widget/spk_widget.hpp"
 
@@ -21,27 +22,37 @@ namespace spk
 			VerticalExtend
 		};
 
-		class Element
-		{
-			friend class Layout;
+               class Element
+               {
+                       friend class Layout;
 
-		private:
-			spk::SafePointer<spk::Widget> _widget;
-			SizePolicy _sizePolicy;
-			spk::Vector2UInt _size;
+               private:
+                       spk::SafePointer<spk::Widget> _widget;
+                       spk::SafePointer<spk::Layout> _layout;
+                       SizePolicy _sizePolicy;
+                       spk::Vector2UInt _size;
 
-		public:
-			Element();
-			Element(spk::SafePointer<spk::Widget> p_widget, const SizePolicy &p_sizePolicy, const spk::Vector2UInt &p_size);
+               public:
+                       Element();
+                       Element(spk::SafePointer<spk::Widget> p_widget, const SizePolicy &p_sizePolicy, const spk::Vector2UInt &p_size);
+                       Element(spk::SafePointer<spk::Layout> p_layout, const SizePolicy &p_sizePolicy, const spk::Vector2UInt &p_size);
 
-			const spk::SafePointer<spk::Widget> &widget() const;
+                       const spk::SafePointer<spk::Widget> &widget() const;
+                       const spk::SafePointer<spk::Layout> &layout() const;
 
-			void setSizePolicy(const SizePolicy &p_sizePolicy);
-			const SizePolicy &sizePolicy() const;
+                       bool isWidget() const;
+                       bool isLayout() const;
 
-			void setSize(const spk::Vector2UInt &p_size);
-			const spk::Vector2UInt &size() const;
-		};
+                       spk::Vector2UInt minimalSize() const;
+                       spk::Vector2UInt maximalSize() const;
+                       void setGeometry(const spk::Geometry2D &p_geometry);
+
+                       void setSizePolicy(const SizePolicy &p_sizePolicy);
+                       const SizePolicy &sizePolicy() const;
+
+                       void setSize(const spk::Vector2UInt &p_size);
+                       const spk::Vector2UInt &size() const;
+               };
 
 	protected:
 		std::vector<std::unique_ptr<Element>> _elements;
@@ -50,14 +61,19 @@ namespace spk
 
 		void resizeElements(const size_t &p_size);
 
-	public:
-		virtual void setGeometry(const spk::Geometry2D &p_geometry) = 0;
+        public:
+                virtual void setGeometry(const spk::Geometry2D &p_geometry) = 0;
 
-		void clear();
+               virtual spk::Vector2UInt minimalSize() const;
+               virtual spk::Vector2UInt maximalSize() const;
 
-		spk::SafePointer<Element> addWidget(spk::SafePointer<spk::Widget> p_widget, const SizePolicy &p_sizePolicy = SizePolicy::Extend);
-		void removeWidget(spk::SafePointer<Element> p_element);
-		void removeWidget(spk::SafePointer<spk::Widget> p_widget);
+                void clear();
+
+                spk::SafePointer<Element> addWidget(spk::SafePointer<spk::Widget> p_widget, const SizePolicy &p_sizePolicy = SizePolicy::Extend);
+               spk::SafePointer<Element> addLayout(spk::SafePointer<spk::Layout> p_layout, const SizePolicy &p_sizePolicy = SizePolicy::Extend);
+                void removeWidget(spk::SafePointer<Element> p_element);
+                void removeWidget(spk::SafePointer<spk::Widget> p_widget);
+               void removeLayout(spk::SafePointer<spk::Layout> p_layout);
 
 		void setElementPadding(const spk::Vector2UInt &p_padding);
 		const spk::Vector2UInt &elementPadding() const;

--- a/include/widget/spk_linear_layout.hpp
+++ b/include/widget/spk_linear_layout.hpp
@@ -25,16 +25,16 @@ namespace spk
 			std::vector<int> primarySize(count, 0);
 			std::vector<bool> isExt(count, false);
 
-			for (size_t i = 0; i < count; ++i)
-			{
-				Element *elt = _elements[i].get();
-				if (elt == nullptr || elt->widget() == nullptr)
-					continue;
+                       for (size_t i = 0; i < count; ++i)
+                       {
+                               Element *elt = _elements[i].get();
+                               if (elt == nullptr || (elt->widget() == nullptr && elt->layout() == nullptr))
+                                       continue;
 
-				int requested = (isHorizontal ? elt->size().x : elt->size().y);
+                               int requested = (isHorizontal ? elt->size().x : elt->size().y);
 
-				spk::Vector2Int minSize = elt->widget()->minimalSize();
-				spk::Vector2Int maxSize = elt->widget()->maximalSize();
+                               spk::Vector2Int minSize = elt->minimalSize();
+                               spk::Vector2Int maxSize = elt->maximalSize();
 
 				switch (elt->sizePolicy())
 				{
@@ -121,10 +121,10 @@ namespace spk
 			{
 				Element *elt = _elements[i].get();
 
-				if (elt != nullptr && elt->widget() != nullptr)
-				{
-					spk::Vector2Int pos = p_geometry.anchor;
-					spk::Vector2Int size = p_geometry.size;
+                               if (elt != nullptr && (elt->widget() != nullptr || elt->layout() != nullptr))
+                               {
+                                       spk::Vector2Int pos = p_geometry.anchor;
+                                       spk::Vector2Int size = p_geometry.size;
 
 					if (isHorizontal)
 					{
@@ -137,7 +137,7 @@ namespace spk
 						size.y = primarySize[i];
 					}
 
-					elt->widget()->setGeometry({pos, size});
+                                       elt->setGeometry({pos, size});
 
 					cursor += ((isHorizontal == true ? size.x : size.y) > 0 ? pad : 0);
 				}
@@ -158,15 +158,15 @@ namespace spk
 			uint32_t    secondaryMax = 0;
 			std::size_t count        = 0;
 
-			for (const auto& elt : _elements)
-			{
-				if (!elt || elt->widget() == nullptr)
-				{
-					continue;
-				}
+                       for (const auto& elt : _elements)
+                       {
+                               if (!elt || (elt->widget() == nullptr && elt->layout() == nullptr))
+                               {
+                                       continue;
+                               }
 
-				++count;
-				const spk::Vector2UInt min = elt->widget()->minimalSize();
+                               ++count;
+                               const spk::Vector2UInt min = elt->minimalSize();
 
 				if (isHorizontal)
 				{

--- a/src/widget/spk_form_layout.cpp
+++ b/src/widget/spk_form_layout.cpp
@@ -37,19 +37,19 @@ namespace spk
 		bool labelColumnIsExpandable = false;
 		bool fieldColumnIsExpandable = false;
 
-		auto updateColumn = [&](Element *p_element,
-								uint32_t &p_columnWidth,
-								bool     &p_columnIsExpandable)
-		{
-			if (p_element == nullptr || p_element->widget() == nullptr)
-			{
-				return;
-			}
+               auto updateColumn = [&](Element *p_element,
+                                                               uint32_t &p_columnWidth,
+                                                               bool     &p_columnIsExpandable)
+               {
+                       if (p_element == nullptr || (p_element->widget() == nullptr && p_element->layout() == nullptr))
+                       {
+                               return;
+                       }
 
-			const spk::Vector2UInt requestedSize = p_element->size();
+                       const spk::Vector2UInt requestedSize = p_element->size();
 
-			switch (p_element->sizePolicy())
-			{
+                       switch (p_element->sizePolicy())
+                       {
 			case SizePolicy::Fixed:
 			{
 				p_columnWidth = std::max(p_columnWidth, requestedSize.x);
@@ -58,14 +58,14 @@ namespace spk
 			case SizePolicy::Minimum:
 			case SizePolicy::VerticalExtend:
 			{
-				p_columnWidth = std::max(p_columnWidth, p_element->widget()->minimalSize().x);
-				break;
-			}
-			case SizePolicy::Maximum:
-			{
-				p_columnWidth = std::min(p_columnWidth, p_element->widget()->maximalSize().x);
-				break;
-			}
+                               p_columnWidth = std::max(p_columnWidth, p_element->minimalSize().x);
+                               break;
+                       }
+                       case SizePolicy::Maximum:
+                       {
+                               p_columnWidth = std::min(p_columnWidth, p_element->maximalSize().x);
+                               break;
+                       }
 			case SizePolicy::Extend:
 			case SizePolicy::HorizontalExtend:
 			{
@@ -75,12 +75,12 @@ namespace spk
 			}
 		};
 
-		auto heightForElement = [](Element *p_element) -> int
-		{
-			if (p_element == nullptr || p_element->widget() == nullptr)
-			{
-				return 0;
-			}
+               auto heightForElement = [](Element *p_element) -> int
+               {
+                       if (p_element == nullptr || (p_element->widget() == nullptr && p_element->layout() == nullptr))
+                       {
+                               return 0;
+                       }
 
 			switch (p_element->sizePolicy())
 			{
@@ -91,17 +91,17 @@ namespace spk
 			case SizePolicy::Minimum:
 			case SizePolicy::HorizontalExtend:
 			{
-				return p_element->widget()->minimalSize().y;
-			}
-			case SizePolicy::Maximum:
-			{	
-				return p_element->widget()->maximalSize().y;
-			}
-			case SizePolicy::Extend:
-			case SizePolicy::VerticalExtend:
-			{
-				return p_element->widget()->minimalSize().y;
-			}
+                               return p_element->minimalSize().y;
+                       }
+                       case SizePolicy::Maximum:
+                       {
+                               return p_element->maximalSize().y;
+                       }
+                       case SizePolicy::Extend:
+                       case SizePolicy::VerticalExtend:
+                       {
+                               return p_element->minimalSize().y;
+                       }
 			}
 			return 0;
 		};
@@ -189,17 +189,17 @@ namespace spk
 				{fieldColumnWidth, rowHeights[row]}
 			);
 
-			Element *labelElement  = _elements[2 * row].get();
-			if (labelElement != nullptr && labelElement->widget())
-			{
-				labelElement->widget()->setGeometry(labelCellGeometry);
-			}
+                       Element *labelElement  = _elements[2 * row].get();
+                       if (labelElement != nullptr && (labelElement->widget() != nullptr || labelElement->layout() != nullptr))
+                       {
+                               labelElement->setGeometry(labelCellGeometry);
+                       }
 
-			Element *fieldElement  = _elements[2 * row + 1].get();
-			if (fieldElement != nullptr && fieldElement->widget())
-			{
-				fieldElement->widget()->setGeometry(fieldCellGeometry);
-			}
+                       Element *fieldElement  = _elements[2 * row + 1].get();
+                       if (fieldElement != nullptr && (fieldElement->widget() != nullptr || fieldElement->layout() != nullptr))
+                       {
+                               fieldElement->setGeometry(fieldCellGeometry);
+                       }
 
 			currentY += static_cast<uint32_t>(rowHeights[row]) + _elementPadding.y;
 		}
@@ -217,14 +217,22 @@ namespace spk
 		uint32_t fieldColumnWidth = 0;
 		std::vector<uint32_t> rowHeights(rowCountValue, 0);
 
-		const auto elementMinW = [](Element* p_element) -> uint32_t
-		{
-			return (p_element && p_element->widget()) ? p_element->widget()->minimalSize().x : 0;
-		};
-		const auto elementMinH = [](Element* p_element) -> uint32_t
-		{
-			return (p_element && p_element->widget()) ? p_element->widget()->minimalSize().y : 0;
-		};
+               const auto elementMinW = [](Element* p_element) -> uint32_t
+               {
+                       if (p_element && (p_element->widget() != nullptr || p_element->layout() != nullptr))
+                       {
+                               return p_element->minimalSize().x;
+                       }
+                       return 0;
+               };
+               const auto elementMinH = [](Element* p_element) -> uint32_t
+               {
+                       if (p_element && (p_element->widget() != nullptr || p_element->layout() != nullptr))
+                       {
+                               return p_element->minimalSize().y;
+                       }
+                       return 0;
+               };
 
 		for (std::size_t row = 0; row < rowCountValue; ++row)
 		{

--- a/src/widget/spk_layout.cpp
+++ b/src/widget/spk_layout.cpp
@@ -1,25 +1,89 @@
 #include "widget/spk_layout.hpp"
+#include <limits>
 
 namespace spk
 {
-	Layout::Element::Element() : 
-		_widget(nullptr),
-		_sizePolicy(SizePolicy::Extend),
-		_size({1, 1})
-	{
-	}
+       Layout::Element::Element() :
+               _widget(nullptr),
+               _layout(nullptr),
+               _sizePolicy(SizePolicy::Extend),
+               _size({1, 1})
+       {
+       }
 
-	Layout::Element::Element(spk::SafePointer<spk::Widget> p_widget, const SizePolicy &p_sizePolicy, const spk::Vector2UInt &p_size) :
-		_widget(p_widget),
-		_sizePolicy(p_sizePolicy),
-		_size(p_size)
-	{
-	}
+       Layout::Element::Element(spk::SafePointer<spk::Widget> p_widget, const SizePolicy &p_sizePolicy, const spk::Vector2UInt &p_size) :
+               _widget(p_widget),
+               _layout(nullptr),
+               _sizePolicy(p_sizePolicy),
+               _size(p_size)
+       {
+       }
 
-	const spk::SafePointer<spk::Widget> &Layout::Element::widget() const
-	{
-		return (_widget);
-	}
+       Layout::Element::Element(spk::SafePointer<spk::Layout> p_layout, const SizePolicy &p_sizePolicy, const spk::Vector2UInt &p_size) :
+               _widget(nullptr),
+               _layout(p_layout),
+               _sizePolicy(p_sizePolicy),
+               _size(p_size)
+       {
+       }
+
+       const spk::SafePointer<spk::Widget> &Layout::Element::widget() const
+       {
+               return (_widget);
+       }
+
+       const spk::SafePointer<spk::Layout> &Layout::Element::layout() const
+       {
+               return (_layout);
+       }
+
+       bool Layout::Element::isWidget() const
+       {
+               return (_widget != nullptr);
+       }
+
+       bool Layout::Element::isLayout() const
+       {
+               return (_layout != nullptr);
+       }
+
+       spk::Vector2UInt Layout::Element::minimalSize() const
+       {
+               if (_widget != nullptr)
+               {
+                       return _widget->minimalSize();
+               }
+               if (_layout != nullptr)
+               {
+                       return _layout->minimalSize();
+               }
+               return {0u, 0u};
+       }
+
+       spk::Vector2UInt Layout::Element::maximalSize() const
+       {
+               if (_widget != nullptr)
+               {
+                       return _widget->maximalSize();
+               }
+               if (_layout != nullptr)
+               {
+                       return _layout->maximalSize();
+               }
+               return {0u, 0u};
+       }
+
+       void Layout::Element::setGeometry(const spk::Geometry2D &p_geometry)
+       {
+               if (_widget != nullptr)
+               {
+                       _widget->setGeometry(p_geometry);
+               }
+               else if (_layout != nullptr)
+               {
+                       _layout->setGeometry(p_geometry);
+               }
+       }
 
 	void Layout::Element::setSizePolicy(const Layout::SizePolicy &p_sizePolicy)
 	{
@@ -39,29 +103,36 @@ namespace spk
 		return (_size);
 	}
 
-	void Layout::resizeElements(const size_t &p_size)
-	{
-		_elements.resize(p_size);
-	}
+       void Layout::resizeElements(const size_t &p_size)
+       {
+               _elements.resize(p_size);
+       }
 
 	void Layout::clear()
 	{
 		_elements.clear();
 	}
 
-	spk::SafePointer<Layout::Element> Layout::addWidget(spk::SafePointer<spk::Widget> p_widget, const SizePolicy &p_sizePolicy)
-	{
-		_elements.push_back(std::unique_ptr<Element>(new Element(p_widget, p_sizePolicy, {0, 0})));
+       spk::SafePointer<Layout::Element> Layout::addWidget(spk::SafePointer<spk::Widget> p_widget, const SizePolicy &p_sizePolicy)
+       {
+               _elements.push_back(std::unique_ptr<Element>(new Element(p_widget, p_sizePolicy, {0, 0})));
 
-		return (_elements.back().get());
-	}
+               return (_elements.back().get());
+       }
 
-	void Layout::removeWidget(spk::SafePointer<spk::Widget> p_widget)
-	{
-		if (p_widget == nullptr)
-		{
-			return ;
-		}
+       spk::SafePointer<Layout::Element> Layout::addLayout(spk::SafePointer<spk::Layout> p_layout, const SizePolicy &p_sizePolicy)
+       {
+               _elements.push_back(std::unique_ptr<Element>(new Element(p_layout, p_sizePolicy, {0, 0})));
+
+               return (_elements.back().get());
+       }
+
+       void Layout::removeWidget(spk::SafePointer<spk::Widget> p_widget)
+       {
+               if (p_widget == nullptr)
+               {
+                       return ;
+               }
 
 		for (auto it = _elements.begin(); it != _elements.end(); ++it)
 		{
@@ -70,16 +141,48 @@ namespace spk
 				_elements.erase(it);
 				resizeElements(_elements.size());
 				return ;
-			}
-		}
-		
-		throw std::runtime_error("Widget [" + spk::StringUtils::wstringToString(p_widget->name()) + "] not contained by the layout");
-	}
+                       }
+               }
 
-	void Layout::removeWidget(spk::SafePointer<Element> p_element)
-	{
-		removeWidget(p_element->widget());
-	}
+               throw std::runtime_error("Widget [" + spk::StringUtils::wstringToString(p_widget->name()) + "] not contained by the layout");
+       }
+
+       void Layout::removeLayout(spk::SafePointer<spk::Layout> p_layout)
+       {
+               if (p_layout == nullptr)
+               {
+                       return;
+               }
+
+               for (auto it = _elements.begin(); it != _elements.end(); ++it)
+               {
+                       if ((*it)->layout() == p_layout)
+                       {
+                               _elements.erase(it);
+                               resizeElements(_elements.size());
+                               return;
+                       }
+               }
+
+               throw std::runtime_error("Layout not contained by the layout");
+       }
+
+       void Layout::removeWidget(spk::SafePointer<Element> p_element)
+       {
+               if (p_element == nullptr)
+               {
+                       return;
+               }
+
+               if (p_element->isWidget())
+               {
+                       removeWidget(p_element->widget());
+               }
+               else if (p_element->isLayout())
+               {
+                       removeLayout(p_element->layout());
+               }
+       }
 
 	void Layout::setElementPadding(const spk::Vector2UInt &p_padding)
 	{
@@ -96,8 +199,18 @@ namespace spk
 		return _elements;
 	}
 
-	std::vector<std::unique_ptr<Layout::Element>> &Layout::elements()
-	{
-		return _elements;
-	}
+       std::vector<std::unique_ptr<Layout::Element>> &Layout::elements()
+       {
+               return _elements;
+       }
+
+       spk::Vector2UInt Layout::minimalSize() const
+       {
+               return {0u, 0u};
+       }
+
+       spk::Vector2UInt Layout::maximalSize() const
+       {
+               return {std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max()};
+       }
 }


### PR DESCRIPTION
## Summary
- add `minimalSize`, `maximalSize` and `setGeometry` helpers on `Layout::Element`
- use new helpers in `GridLayout`, `LinearLayout`, and `FormLayout`
- include `Geometry2D` in layout header

## Testing
- `clang-format -i include/widget/spk_grid_layout.hpp include/widget/spk_layout.hpp include/widget/spk_linear_layout.hpp src/widget/spk_form_layout.cpp src/widget/spk_layout.cpp` *(fails: unknown key 'BeforeBlock')*
- `clang-tidy include/widget/spk_grid_layout.hpp include/widget/spk_layout.hpp include/widget/spk_linear_layout.hpp src/widget/spk_form_layout.cpp src/widget/spk_layout.cpp -- -std=c++20` *(fails: file not found and other warnings)*
- `cmake --preset test-debug` *(fails: Could not find toolchain file)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6884a16671f48325b382a6b8f834cc23