### PR TITLE
Add binding point setup for OpenGL SamplerObject

### DIFF
--- a/include/structure/graphics/opengl/spk_sampler_object.hpp
+++ b/include/structure/graphics/opengl/spk_sampler_object.hpp
@@ -16,36 +16,42 @@
 
 namespace spk::OpenGL
 {
-	class SamplerObject
-	{
-	public:
-		enum class Type : GLenum {
-			Texture1D = GL_TEXTURE_1D,
-			Texture2D = GL_TEXTURE_2D,
-			Texture3D = GL_TEXTURE_3D,
-			TextureCubeMap = GL_TEXTURE_CUBE_MAP
-		};
+       class SamplerObject
+       {
+       public:
+               enum class Type : GLenum
+               {
+                       Texture1D = GL_TEXTURE_1D,
+                       Texture2D = GL_TEXTURE_2D,
+                       Texture3D = GL_TEXTURE_3D,
+                       TextureCubeMap = GL_TEXTURE_CUBE_MAP
+               };
+
+               using BindingPoint = int;
 
 	private:
-		spk::SafePointer<const Texture> _texture = nullptr;
-		std::string _designator;
-		GLint _index = -1;
-		GLint _uniformDestination = -1;
-		Type _type;
+               spk::SafePointer<const Texture> _texture = nullptr;
+               std::string _designator;
+               BindingPoint _bindingPoint = -1;
+               GLint _uniformDestination = -1;
+               Type _type;
 
 	public:
-		SamplerObject();
-		SamplerObject(const std::string &p_name, Type p_type, size_t p_textureIndex);
+               SamplerObject();
+               SamplerObject(const std::string &p_name, Type p_type, BindingPoint p_bindingPoint);
 
 		SamplerObject(const SamplerObject &p_other);
 		SamplerObject &operator=(const SamplerObject &p_other);
 		SamplerObject(SamplerObject &&p_other) noexcept;
-		SamplerObject &operator=(SamplerObject &&p_other) noexcept;
+               SamplerObject &operator=(SamplerObject &&p_other) noexcept;
 
 		void bind(const spk::SafePointer<const Texture> &p_texture);
 
-		spk::SafePointer<const Texture> &texture();
-		const spk::SafePointer<const Texture> &texture() const;
+               spk::SafePointer<const Texture> &texture();
+               const spk::SafePointer<const Texture> &texture() const;
+
+               BindingPoint bindingPoint() const;
+               void setBindingPoint(BindingPoint p_bindingPoint);
 
 		void activate();
 		void deactivate();

--- a/src/structure/graphics/opengl/spk_sampler_object.cpp
+++ b/src/structure/graphics/opengl/spk_sampler_object.cpp
@@ -4,89 +4,99 @@
 
 namespace spk::OpenGL
 {
-	SamplerObject::SamplerObject() :
-		_designator(""),
-		_index(-1),
-		_texture(nullptr),
-		_uniformDestination(-1),
-		_type(Type::Texture2D)
-	{
-	}
+       SamplerObject::SamplerObject() :
+               _designator(""),
+               _bindingPoint(-1),
+               _texture(nullptr),
+               _uniformDestination(-1),
+               _type(Type::Texture2D)
+       {
+       }
 
-	SamplerObject::SamplerObject(const std::string &p_name, Type p_type, size_t p_textureIndex) :
-		_designator(p_name),
-		_index(static_cast<GLint>(p_textureIndex)),
-		_texture(nullptr),
-		_uniformDestination(-1),
-		_type(p_type)
-	{
-	}
+       SamplerObject::SamplerObject(const std::string &p_name, Type p_type, BindingPoint p_bindingPoint) :
+               _designator(p_name),
+               _bindingPoint(static_cast<GLint>(p_bindingPoint)),
+               _texture(nullptr),
+               _uniformDestination(-1),
+               _type(p_type)
+       {
+       }
 
-	SamplerObject::SamplerObject(const SamplerObject &p_other) :
-		_designator(p_other._designator),
-		_index(p_other._index),
-		_texture(p_other._texture),
-		_type(p_other._type),
-		_uniformDestination(p_other._uniformDestination)
-	{
-	}
+       SamplerObject::SamplerObject(const SamplerObject &p_other) :
+               _designator(p_other._designator),
+               _bindingPoint(p_other._bindingPoint),
+               _texture(p_other._texture),
+               _type(p_other._type),
+               _uniformDestination(p_other._uniformDestination)
+       {
+       }
 
-	SamplerObject &SamplerObject::operator=(const SamplerObject &p_other)
-	{
-		if (this != &p_other)
-		{
-			_designator = p_other._designator;
-			_index = p_other._index;
-			_texture = p_other._texture;
-			_type = p_other._type;
-			_uniformDestination = p_other._uniformDestination;
-		}
-		return *this;
-	}
+       SamplerObject &SamplerObject::operator=(const SamplerObject &p_other)
+       {
+               if (this != &p_other)
+               {
+                       _designator = p_other._designator;
+                       _bindingPoint = p_other._bindingPoint;
+                       _texture = p_other._texture;
+                       _type = p_other._type;
+                       _uniformDestination = p_other._uniformDestination;
+               }
+               return *this;
+       }
 
-	SamplerObject::SamplerObject(SamplerObject &&p_other) noexcept :
-		_designator(std::move(p_other._designator)),
-		_index(p_other._index),
-		_texture(p_other._texture),
-		_type(p_other._type),
-		_uniformDestination(p_other._uniformDestination)
-	{
-		p_other._texture = nullptr;
-		p_other._index = -1;
-		p_other._uniformDestination = -1;
-	}
+       SamplerObject::SamplerObject(SamplerObject &&p_other) noexcept :
+               _designator(std::move(p_other._designator)),
+               _bindingPoint(p_other._bindingPoint),
+               _texture(p_other._texture),
+               _type(p_other._type),
+               _uniformDestination(p_other._uniformDestination)
+       {
+               p_other._texture = nullptr;
+               p_other._bindingPoint = -1;
+               p_other._uniformDestination = -1;
+       }
 
-	SamplerObject &SamplerObject::operator=(SamplerObject &&p_other) noexcept
-	{
-		if (this != &p_other)
-		{
-			_designator = std::move(p_other._designator);
-			_index = p_other._index;
-			_texture = p_other._texture;
-			_type = p_other._type;
-			_uniformDestination = p_other._uniformDestination;
+       SamplerObject &SamplerObject::operator=(SamplerObject &&p_other) noexcept
+       {
+               if (this != &p_other)
+               {
+                       _designator = std::move(p_other._designator);
+                       _bindingPoint = p_other._bindingPoint;
+                       _texture = p_other._texture;
+                       _type = p_other._type;
+                       _uniformDestination = p_other._uniformDestination;
 
-			p_other._texture = nullptr;
-			p_other._index = -1;
-			p_other._uniformDestination = -1;
-		}
-		return *this;
-	}
+                       p_other._texture = nullptr;
+                       p_other._bindingPoint = -1;
+                       p_other._uniformDestination = -1;
+               }
+               return *this;
+       }
 
 	void SamplerObject::bind(const spk::SafePointer<const Texture> &p_texture)
 	{
 		_texture = p_texture;
 	}
 
-	spk::SafePointer<const Texture> &SamplerObject::texture()
-	{
-		return _texture;
-	}
+       spk::SafePointer<const Texture> &SamplerObject::texture()
+       {
+               return _texture;
+       }
 
-	const spk::SafePointer<const Texture> &SamplerObject::texture() const
-	{
-		return _texture;
-	}
+       const spk::SafePointer<const Texture> &SamplerObject::texture() const
+       {
+               return _texture;
+       }
+
+       SamplerObject::BindingPoint SamplerObject::bindingPoint() const
+       {
+               return _bindingPoint;
+       }
+
+       void SamplerObject::setBindingPoint(BindingPoint p_bindingPoint)
+       {
+               _bindingPoint = p_bindingPoint;
+       }
 
 	void SamplerObject::activate()
 	{
@@ -96,11 +106,11 @@ namespace spk::OpenGL
 			glGetIntegerv(GL_CURRENT_PROGRAM, &prog);
 			glUseProgram(prog);
 
-			_uniformDestination = glGetUniformLocation(prog, _designator.c_str());
-			glUniform1i(_uniformDestination, _index);
-		}
+                       _uniformDestination = glGetUniformLocation(prog, _designator.c_str());
+                       glUniform1i(_uniformDestination, _bindingPoint);
+               }
 
-		glActiveTexture(GL_TEXTURE0 + _index);
+               glActiveTexture(GL_TEXTURE0 + _bindingPoint);
 
 		if (_texture == nullptr)
 		{


### PR DESCRIPTION
## Summary
- allow specifying an OpenGL sampler binding point
- expose getter/setter for sampler binding point

## Testing
- `clang-format-17 -i include/structure/graphics/opengl/spk_sampler_object.hpp src/structure/graphics/opengl/spk_sampler_object.cpp >/tmp/clang_format.log && tail -n 20 /tmp/clang_format.log`
  - failed: unknown key in `.clang-format`
- `clang-tidy src/structure/graphics/opengl/spk_sampler_object.cpp include/structure/graphics/opengl/spk_sampler_object.hpp >/tmp/clang_tidy.log && tail -n 20 /tmp/clang_tidy.log`
  - failed: no compilation database
- `cmake --preset test-debug`
  - failed: missing vcpkg toolchain
- `cmake --build --preset test-debug`
  - failed: build directory missing
- `ctest --preset test-debug`
  - failed: no tests were found

------
https://chatgpt.com/codex/tasks/task_e_688a24f3faf88325ae290c7667ade06e