### PR TITLE
docs: expand first steps tutorials with calculator example

### DIFF
--- a/firstStep/README.md
+++ b/firstStep/README.md
@@ -1,0 +1,8 @@
+# First Steps with Sparkle
+
+This directory contains introductory guides for the Sparkle library.
+
+- [Hello Triangle](hello_triangle.md) – start with a window and empty widget, then build shaders,
+  buffers, and a uniform colour to render a triangle in the centre of the screen.
+- [Simple Calculator](simple_calculator.md) – combine text labels and push buttons to build a
+  tiny calculator application.

--- a/firstStep/hello_triangle.md
+++ b/firstStep/hello_triangle.md
@@ -1,0 +1,224 @@
+# Hello Triangle
+
+This tutorial builds a minimal Sparkle program step by step. We start with an
+empty application window, add a custom widget, compile a shader, describe the
+geometry in pixel coordinates, and finally introduce a uniform buffer object
+for colour.
+
+## 1. Create the application window
+
+Begin with a basic `main` function that creates a window and runs the event
+loop.
+
+```cpp
+int main()
+{
+    spk::GraphicalApplication app;
+    auto window = app.createWindow(L"Triangle", {{0,0},{800,600}});
+
+    return app.run();
+}
+```
+
+## 2. Define an empty widget
+
+Declare a widget subclass. It will later hold the shader program and buffers,
+but for now the callbacks remain empty.
+
+```cpp
+#include <sparkle.hpp>
+
+class TriangleWidget : public spk::Widget
+{
+    spk::OpenGL::Program _program;
+    spk::OpenGL::BufferSet _buffers;
+
+public:
+    TriangleWidget(const std::wstring& name, spk::SafePointer<spk::Widget> parent)
+        : spk::Widget(name, parent)
+    {}
+
+protected:
+    void _onGeometryChange() override {}
+    void _onPaintEvent(spk::PaintEvent&) override {}
+};
+```
+
+## 3. Compile the shader and describe attributes
+
+Create a vertex and fragment shader that pass through a colour attribute. Then
+configure the buffer layout for position, layer, and colour.
+
+```cpp
+const char* vertexSrc = R"(
+    #version 450
+    layout(location=0) in vec2 inPosition;
+    layout(location=1) in float inLayer;
+    layout(location=2) in vec4 inColor;
+    out vec4 vColor;
+    void main() {
+        gl_Position = vec4(inPosition, inLayer, 1.0);
+        vColor = inColor;
+    }
+)";
+
+const char* fragmentSrc = R"(
+    #version 450
+    in vec4 vColor;
+    layout(location=0) out vec4 outColor;
+    void main() { outColor = vColor; }
+)";
+
+_program = spk::OpenGL::Program(vertexSrc, fragmentSrc);
+
+_buffers = spk::OpenGL::BufferSet({
+    {0, spk::OpenGL::LayoutBufferObject::Attribute::Type::Vector2}, // position
+    {1, spk::OpenGL::LayoutBufferObject::Attribute::Type::Float},   // layer
+    {2, spk::OpenGL::LayoutBufferObject::Attribute::Type::Vector4}  // colour
+});
+```
+
+## 4. Fill buffers on geometry change and paint
+
+Populate the buffers inside `_onGeometryChange` so resizing the widget rebuilds
+the geometry. The positions are supplied in pixel coordinates and converted to
+OpenGL space via `spk::Viewport`.
+
+```cpp
+void TriangleWidget::_onGeometryChange()
+{
+    struct Vertex { spk::Vector2 pos; float layer; spk::Color color; };
+
+    auto geom = geometry();
+    spk::Vector2Int center = {geom.x + static_cast<int>(geom.width) / 2,
+                              geom.y + static_cast<int>(geom.height) / 2};
+    int size = 100; // triangle half-size in pixels
+
+    spk::Vector3 top   = spk::Viewport::convertScreenToOpenGL({center.x, center.y - size}, 0.0f);
+    spk::Vector3 left  = spk::Viewport::convertScreenToOpenGL({center.x - size, center.y + size}, 0.0f);
+    spk::Vector3 right = spk::Viewport::convertScreenToOpenGL({center.x + size, center.y + size}, 0.0f);
+
+    _buffers.layout().clear();
+    _buffers.indexes().clear();
+
+    _buffers.layout() << Vertex{top.xy(),   top.z,  spk::Color::green}
+                      << Vertex{left.xy(),  left.z, spk::Color::green}
+                      << Vertex{right.xy(), right.z, spk::Color::green};
+    _buffers.indexes() << 0 << 1 << 2;
+
+    _buffers.layout().validate();
+    _buffers.indexes().validate();
+}
+
+void TriangleWidget::_onPaintEvent(spk::PaintEvent&)
+{
+    _program.activate();
+    _buffers.activate();
+    _program.render(_buffers.indexes().nbIndexes(), 1);
+    _buffers.deactivate();
+    _program.deactivate();
+}
+```
+
+Instantiate the widget after creating the window:
+
+```cpp
+int main()
+{
+    spk::GraphicalApplication app;
+    auto window = app.createWindow(L"Triangle", {{0,0},{800,600}});
+
+    TriangleWidget tri(L"TriangleWidget", window->widget());
+    tri.setGeometry(window->geometry());
+    tri.activate();
+
+    return app.run();
+}
+```
+
+Running this displays a green triangle centred in the window.
+
+## 5. Use a uniform buffer for colour
+
+To demonstrate uniform buffers, remove the colour attribute and supply a colour
+through a `spk::OpenGL::UniformBufferObject`.
+
+Update the shaders:
+
+```cpp
+const char* vertexSrc = R"(
+    #version 450
+    layout(location=0) in vec2 inPosition;
+    layout(location=1) in float inLayer;
+    void main() { gl_Position = vec4(inPosition, inLayer, 1.0); }
+)";
+
+const char* fragmentSrc = R"(
+    #version 450
+    layout(location=0) out vec4 outColor;
+    layout(std140, binding = 0) uniform ColorUBO { vec4 color; };
+    void main() { outColor = color; }
+)";
+
+_program = spk::OpenGL::Program(vertexSrc, fragmentSrc);
+```
+
+Reconfigure the buffer layout without the colour attribute and update the
+geometry building code accordingly:
+
+```cpp
+_buffers = spk::OpenGL::BufferSet({
+    {0, spk::OpenGL::LayoutBufferObject::Attribute::Type::Vector2},
+    {1, spk::OpenGL::LayoutBufferObject::Attribute::Type::Float}
+});
+
+void TriangleWidget::_onGeometryChange()
+{
+    struct Vertex { spk::Vector2 pos; float layer; };
+
+    auto geom = geometry();
+    spk::Vector2Int center = {geom.x + static_cast<int>(geom.width) / 2,
+                              geom.y + static_cast<int>(geom.height) / 2};
+    int size = 100;
+
+    spk::Vector3 top   = spk::Viewport::convertScreenToOpenGL({center.x, center.y - size}, 0.0f);
+    spk::Vector3 left  = spk::Viewport::convertScreenToOpenGL({center.x - size, center.y + size}, 0.0f);
+    spk::Vector3 right = spk::Viewport::convertScreenToOpenGL({center.x + size, center.y + size}, 0.0f);
+
+    _buffers.layout().clear();
+    _buffers.indexes().clear();
+
+    _buffers.layout() << Vertex{top.xy(),   top.z}
+                      << Vertex{left.xy(),  left.z}
+                      << Vertex{right.xy(), right.z};
+    _buffers.indexes() << 0 << 1 << 2;
+
+    _buffers.layout().validate();
+    _buffers.indexes().validate();
+}
+```
+
+Create the uniform buffer object and use it during rendering:
+
+```cpp
+spk::OpenGL::UniformBufferObject _colorUbo;
+
+_colorUbo = spk::OpenGL::UniformBufferObject(L"ColorUBO", 0, 16);
+_colorUbo.addElement(L"color", 0, 16);
+_colorUbo[L"color"] = spk::Color::green;
+_colorUbo.validate();
+
+void TriangleWidget::_onPaintEvent(spk::PaintEvent&)
+{
+    _program.activate();
+    _buffers.activate();
+    _colorUbo.activate();
+    _program.render(_buffers.indexes().nbIndexes(), 1);
+    _colorUbo.deactivate();
+    _buffers.deactivate();
+    _program.deactivate();
+}
+```
+
+The triangle now renders using the colour stored in the uniform buffer.
+

--- a/firstStep/simple_calculator.md
+++ b/firstStep/simple_calculator.md
@@ -1,0 +1,230 @@
+# Simple Calculator
+
+Build a tiny calculator with Sparkle widgets. We start by manually placing
+digit buttons, then switch to a layout, and finally add a display with a few
+operations.
+
+## 1. Create the application window
+
+Begin with a minimal `main` function that creates a window and runs the event
+loop.
+
+```cpp
+int main()
+{
+    spk::GraphicalApplication app;
+    auto window = app.createWindow(L"Calculator", {{0,0},{300,400}});
+
+    return app.run();
+}
+```
+
+## 2. Manually place digit buttons
+
+Create a widget that owns ten `spk::PushButton` objects and positions them
+manually inside `onGeometryChange`.
+
+```cpp
+#include <sparkle.hpp>
+
+class ManualDigitsWidget : public spk::Widget
+{
+    std::array<std::unique_ptr<spk::PushButton>,10> _digits;
+
+    void _onGeometryChange() override
+    {
+        spk::Vec2i cell = {geometry().size.x/3, geometry().size.y/4};
+        for (int i = 0; i < 10; ++i)
+        {
+            int col = i % 3;
+            int row = i / 3;
+            spk::Vec2i pos = {col*cell.x, row*cell.y};
+            _digits[i]->setGeometry({pos, cell});
+        }
+    }
+
+public:
+    ManualDigitsWidget(const std::wstring& name, spk::SafePointer<spk::Widget> parent)
+        : spk::Widget(name, parent)
+    {
+        for (int i = 0; i < 10; ++i)
+        {
+            _digits[i] = std::make_unique<spk::PushButton>(name + L"/" + std::to_wstring(i), this);
+            _digits[i]->setText(std::to_wstring(i));
+            _digits[i]->activate();
+        }
+    }
+};
+```
+
+Instantiate it:
+
+```cpp
+int main()
+{
+    spk::GraphicalApplication app;
+    auto window = app.createWindow(L"Calculator", {{0,0},{300,400}});
+
+    ManualDigitsWidget digits(L"Digits", window->widget());
+    digits.setGeometry(window->geometry());
+    digits.activate();
+
+    return app.run();
+}
+```
+
+At this stage the buttons appear but every position is hard coded.
+
+## 3. Replace manual positioning with a layout
+
+Layouts automatically handle geometry. Swap the manual placement for a
+`spk::GridLayout<3,4>` that arranges the digits.
+
+```cpp
+class DigitLayoutWidget : public spk::Widget
+{
+    spk::GridLayout<3,4> _layout;
+    std::array<std::unique_ptr<spk::PushButton>,10> _digits;
+
+    void _onGeometryChange() override
+    {
+        _layout.setGeometry({0, geometry().size});
+    }
+
+public:
+    DigitLayoutWidget(const std::wstring& name, spk::SafePointer<spk::Widget> parent)
+        : spk::Widget(name, parent)
+    {
+        for (int i = 0; i < 10; ++i)
+        {
+            _digits[i] = std::make_unique<spk::PushButton>(name + L"/" + std::to_wstring(i), this);
+            _digits[i]->setText(std::to_wstring(i));
+            _digits[i]->activate();
+        }
+
+        for (int i = 1; i <= 9; ++i)
+        {
+            int col = (i-1)%3;
+            int row = (i-1)/3;
+            _layout.setWidget(col, row, _digits[i].get(), spk::Layout::SizePolicy::Extend);
+        }
+        _layout.setWidget(1,3,_digits[0].get(), spk::Layout::SizePolicy::Extend);
+    }
+};
+```
+
+Use it in `main` exactly like before. The layout now arranges the buttons and
+resizes them when the window changes.
+
+## 4. Add the display and operations
+
+Extend the widget with a `spk::TextLabel` for the current value and three more
+buttons. Hook up callbacks to make the calculator add numbers.
+
+```cpp
+class CalculatorWidget : public spk::Widget
+{
+    spk::GridLayout<4,5> _layout;
+    spk::TextLabel _display;
+    std::array<std::unique_ptr<spk::PushButton>,10> _digits;
+    spk::PushButton _plus;
+    spk::PushButton _equals;
+    spk::PushButton _clear;
+
+    int _accumulator = 0;
+    bool _waitingSecond = false;
+
+    void _onGeometryChange() override
+    {
+        _layout.setGeometry({0, geometry().size});
+    }
+
+public:
+    CalculatorWidget(const std::wstring& name, spk::SafePointer<spk::Widget> parent)
+        : spk::Widget(name, parent),
+          _display(name + L"/Display", this),
+          _plus(name + L"/Plus", this),
+          _equals(name + L"/Equals", this),
+          _clear(name + L"/Clear", this)
+    {
+        _layout.setElementPadding({5,5});
+
+        _display.setFontSize({20,1});
+        _display.setTextAlignment(spk::HorizontalAlignment::Right,
+                                  spk::VerticalAlignment::Centered);
+        _display.activate();
+        _layout.setWidget(0,0,&_display, spk::Layout::SizePolicy::HorizontalExtend);
+
+        for (int i = 0; i < 10; ++i)
+        {
+            _digits[i] = std::make_unique<spk::PushButton>(name + L"/" + std::to_wstring(i), this);
+            _digits[i]->setText(std::to_wstring(i));
+            _digits[i]->activate();
+            _digits[i]->subscribe([this, i]() {
+                _display.setText(_display.text() + std::to_wstring(i));
+            });
+        }
+
+        for (int i = 1; i <= 9; ++i)
+        {
+            int col = (i-1)%3;
+            int row = 1 + (i-1)/3;
+            _layout.setWidget(col, row, _digits[i].get(), spk::Layout::SizePolicy::Extend);
+        }
+        _layout.setWidget(1,4,_digits[0].get(), spk::Layout::SizePolicy::Extend);
+
+        _plus.setText(L"+");
+        _equals.setText(L"=");
+        _clear.setText(L"C");
+        _plus.activate();
+        _equals.activate();
+        _clear.activate();
+
+        _layout.setWidget(3,1,&_plus);
+        _layout.setWidget(3,2,&_equals);
+        _layout.setWidget(3,3,&_clear);
+
+        _plus.subscribe([this]() {
+            _accumulator = std::stoi(_display.text());
+            _display.setText(L"");
+            _waitingSecond = true;
+        });
+
+        _equals.subscribe([this]() {
+            if (_waitingSecond)
+            {
+                _accumulator += std::stoi(_display.text());
+                _display.setText(std::to_wstring(_accumulator));
+                _waitingSecond = false;
+            }
+        });
+
+        _clear.subscribe([this]() {
+            _display.setText(L"");
+            _accumulator = 0;
+            _waitingSecond = false;
+        });
+    }
+};
+```
+
+Instantiate the final widget:
+
+```cpp
+int main()
+{
+    spk::GraphicalApplication app;
+    auto window = app.createWindow(L"Calculator", {{0,0},{300,400}});
+
+    CalculatorWidget calc(L"Calc", window->widget());
+    calc.setGeometry(window->geometry());
+    calc.activate();
+
+    return app.run();
+}
+```
+
+Running the program now shows a functional calculator. The tutorial illustrated
+how to manually place widgets, adopt layouts, and combine widgets into an
+interactive application.
+


### PR DESCRIPTION
## Summary
- reorganize Hello Triangle tutorial into logical chapters from window creation to uniform buffer usage
- expand calculator guide into step-by-step walkthrough from manual widget placement to a working layout-driven calculator
- link calculator guide from First Steps index

## Testing
- `ctest 2>&1 | head -n 50` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_689656a9defc83258172739d31323b3b