### PR TITLE
Fix polygon edge handling for block occlusion

### DIFF
--- a/include/structure/math/spk_polygon.hpp
+++ b/include/structure/math/spk_polygon.hpp
@@ -4,6 +4,7 @@
 #include "structure/math/spk_vector3.hpp"
 #include <cmath>
 #include <vector>
+#include <limits>
 
 #include "spk_debug_macro.hpp"
 
@@ -65,11 +66,11 @@ namespace spk
 			spk::Vector3 normal = (points[1] - origin).cross(points[2] - origin).normalize();
 			spk::Vector3 v = normal.cross(u);
 
-			auto project = [&](const spk::Vector3 &pt)
-			{
-				spk::Vector3 rel = pt - origin;
-				return spk::Vector2(rel.dot(u), rel.dot(v));
-			};
+                        auto project = [&](const spk::Vector3 &p_point)
+                        {
+                                spk::Vector3 rel = p_point - origin;
+                                return spk::Vector2(rel.dot(u), rel.dot(v));
+                        };
 
 			std::vector<spk::Vector2> poly2d;
 			poly2d.reserve(points.size());
@@ -78,29 +79,69 @@ namespace spk
 				poly2d.push_back(project(pt));
 			}
 
-			auto inside = [&](const spk::Vector2 &p)
-			{
-				bool result = false;
-				for (size_t i = 0, j = poly2d.size() - 1; i < poly2d.size(); j = i++)
-				{
-					const spk::Vector2 &pi = poly2d[i];
-					const spk::Vector2 &pj = poly2d[j];
-					if (((pi.y > p.y) != (pj.y > p.y)) && (p.x < (pj.x - pi.x) * (p.y - pi.y) / (pj.y - pi.y) + pi.x))
-					{
-						result = (result == false);
-					}
-				}
-				return result;
-			};
+                        auto onEdge = [&](const spk::Vector2 &p_point)
+                        {
+                                for (size_t i = 0, j = poly2d.size() - 1; i < poly2d.size(); j = i++)
+                                {
+                                        const spk::Vector2 &pi = poly2d[i];
+                                        const spk::Vector2 &pj = poly2d[j];
+                                        float cross = (pj.x - pi.x) * (p_point.y - pi.y) - (pj.y - pi.y) * (p_point.x - pi.x);
+                                        if (std::abs(cross) <= std::numeric_limits<float>::epsilon() &&
+                                            p_point.x >= std::min(pi.x, pj.x) && p_point.x <= std::max(pi.x, pj.x) &&
+                                            p_point.y >= std::min(pi.y, pj.y) && p_point.y <= std::max(pi.y, pj.y))
+                                        {
+                                                return true;
+                                        }
+                                }
+                                return false;
+                        };
 
-			for (const spk::Vector3 &pt : p_polygon.points)
-			{
-				if (inside(project(pt)) == false)
-				{
-					return false;
-				}
-			}
-			return true;
-		}
-	};
+                        auto inside = [&](const spk::Vector2 &p_point)
+                        {
+                                bool result = false;
+                                for (size_t i = 0, j = poly2d.size() - 1; i < poly2d.size(); j = i++)
+                                {
+                                        const spk::Vector2 &pi = poly2d[i];
+                                        const spk::Vector2 &pj = poly2d[j];
+                                        if (((pi.y > p_point.y) != (pj.y > p_point.y)))
+                                        {
+                                                float intersectX = (pj.x - pi.x) * (p_point.y - pi.y) / (pj.y - pi.y) + pi.x;
+                                                if (std::abs(intersectX - p_point.x) <= std::numeric_limits<float>::epsilon())
+                                                {
+                                                        return true;
+                                                }
+                                                if (p_point.x < intersectX)
+                                                {
+                                                        result = (result == false);
+                                                }
+                                        }
+                                        else
+                                        {
+                                                float cross = (p_point.x - pi.x) * (pj.y - pi.y) - (p_point.y - pi.y) * (pj.x - pi.x);
+                                                if (std::abs(cross) <= std::numeric_limits<float>::epsilon() &&
+                                                    p_point.x >= std::min(pi.x, pj.x) && p_point.x <= std::max(pi.x, pj.x) &&
+                                                    p_point.y >= std::min(pi.y, pj.y) && p_point.y <= std::max(pi.y, pj.y))
+                                                {
+                                                        return true;
+                                                }
+                                        }
+                                }
+                                return result;
+                        };
+
+                        for (const spk::Vector3 &pt : p_polygon.points)
+                        {
+                                spk::Vector2 projected = project(pt);
+                                if (onEdge(projected) == true)
+                                {
+                                        continue;
+                                }
+                                if (inside(projected) == false)
+                                {
+                                        return false;
+                                }
+                        }
+                        return true;
+                }
+        };
 }


### PR DESCRIPTION
## Summary
- fix `spk::Polygon::contains` so points on shared edges are treated as inside

## Testing
- `clang-format -i include/structure/math/spk_polygon.hpp` *(fails: unknown key 'BeforeFunctionBody')*
- `clang-tidy include/structure/math/spk_polygon.hpp -p build --quiet` *(fails: no compilation database)*
- `cmake --preset test-debug` *(fails: could not find toolchain file & Ninja)*

------
https://chatgpt.com/codex/tasks/task_e_68a2451b26fc8325b84d97425c3f7419