### PR TITLE
Use mesh material in ObjMeshRenderer

### DIFF
--- a/include/structure/engine/spk_obj_mesh.hpp
+++ b/include/structure/engine/spk_obj_mesh.hpp
@@ -3,19 +3,25 @@
 #include <filesystem>
 #include <string>
 
-#include "structure/engine/spk_vertex.hpp"
 #include "structure/engine/spk_mesh.hpp"
+#include "structure/engine/spk_vertex.hpp"
+#include "structure/graphics/texture/spk_texture.hpp"
+#include "structure/spk_safe_pointer.hpp"
 
 namespace spk
 {
 	class ObjMesh : public TMesh<Vertex>
 	{
 	private:
+		spk::SafePointer<const spk::Texture> _material;
 
 	public:
 		ObjMesh() = default;
 
-		void applyOffset(const spk::Vector3& p_offset);
+		void setMaterial(spk::SafePointer<const spk::Texture> p_material);
+		const spk::SafePointer<const spk::Texture> &material() const;
+
+		void applyOffset(const spk::Vector3 &p_offset);
 
 		static ObjMesh loadFromString(const std::string &p_input);
 		static ObjMesh loadFromFile(const std::filesystem::path &p_path);

--- a/include/structure/engine/spk_obj_mesh_renderer.hpp
+++ b/include/structure/engine/spk_obj_mesh_renderer.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
-#include "structure/engine/spk_obj_mesh.hpp"
 #include "structure/engine/spk_component.hpp"
+#include "structure/engine/spk_obj_mesh.hpp"
+#include "structure/engine/spk_transform.hpp"
 #include "structure/graphics/lumina/spk_shader.hpp"
 #include "structure/graphics/lumina/spk_shader_object_factory.hpp"
-#include "structure/graphics/texture/spk_image.hpp"
 #include "structure/spk_safe_pointer.hpp"
-#include "structure/engine/spk_transform.hpp"
 
 namespace spk
 {
@@ -36,7 +35,7 @@ namespace spk
 
 			void setTransform(const spk::Transform &p_transform);
 			void setTexture(const spk::SafePointer<const spk::Texture> &p_texture);
-			const spk::SafePointer<const spk::Texture>& texture() const;
+			const spk::SafePointer<const spk::Texture> &texture() const;
 		};
 
 	private:
@@ -45,13 +44,13 @@ namespace spk
 		spk::ContractProvider::Contract _onOwnerTransformEditionContract;
 
 	public:
-		ObjMeshRenderer(const std::wstring& p_name);
+		ObjMeshRenderer(const std::wstring &p_name);
 
 		void setTexture(spk::SafePointer<const spk::Texture> p_texture);
 		const spk::SafePointer<const spk::Texture> &texture() const;
 
-		void setMesh(const spk::SafePointer<const spk::ObjMesh>& p_mesh);
-		const spk::SafePointer<const spk::ObjMesh>& mesh() const;
+		void setMesh(const spk::SafePointer<const spk::ObjMesh> &p_mesh);
+		const spk::SafePointer<const spk::ObjMesh> &mesh() const;
 
 		void onPaintEvent(spk::PaintEvent &p_event) override;
 		void start() override;

--- a/src/structure/engine/spk_obj_mesh_renderer.cpp
+++ b/src/structure/engine/spk_obj_mesh_renderer.cpp
@@ -147,6 +147,7 @@ void main()
 		if (_mesh != nullptr)
 		{
 			_painter.prepare(*_mesh);
+			_painter.setTexture(_mesh->material());
 		}
 		_painter.validate();
 	}


### PR DESCRIPTION
## Summary
- Support storing a texture material in `ObjMesh` with accessor methods.
- Parse referenced MTL files when loading OBJ meshes to assign diffuse texture as material.
- Update `ObjMeshRenderer` to automatically bind its mesh's material texture during rendering.

## Testing
- `clang-format -i include/structure/engine/spk_obj_mesh.hpp src/structure/engine/spk_obj_mesh.cpp src/structure/engine/spk_obj_mesh_renderer.cpp`
- `clang-tidy include/structure/engine/spk_obj_mesh.hpp src/structure/engine/spk_obj_mesh.cpp src/structure/engine/spk_obj_mesh_renderer.cpp -- -std=c++20` *(failed: compiler errors and numerous warnings)*
- `cmake --preset test-debug` *(failed: missing Ninja and vcpkg toolchain)*
- `cmake --build --preset test-debug` *(failed: build directory missing)*
- `ctest --preset test-debug` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7728950e8832592f138a60a48c790