### PR TITLE
Preserve custom textures for OBJ meshes

### DIFF
--- a/src/structure/engine/spk_obj_mesh.cpp
+++ b/src/structure/engine/spk_obj_mesh.cpp
@@ -180,6 +180,8 @@ namespace spk
 
 	ObjMesh ObjMesh::loadFromFile(const std::filesystem::path &p_path)
 	{
+		spk::cout << L"[ObjMesh] Loading OBJ from " << spk::StringUtils::stringToWString(p_path.string()) << std::endl;
+
 		std::ifstream file(p_path);
 		if (file.is_open() == false)
 		{
@@ -199,6 +201,7 @@ namespace spk
 			if (prefix == "mtllib")
 			{
 				lineStream >> mtllib;
+				spk::cout << L"[ObjMesh] Found mtllib " << spk::StringUtils::stringToWString(mtllib) << std::endl;
 			}
 		}
 
@@ -221,10 +224,15 @@ namespace spk
 						std::string textureFile;
 						mtlStream >> textureFile;
 						auto texturePath = mtlPath.parent_path() / textureFile;
+						spk::cout << L"[ObjMesh] Loading texture " << spk::StringUtils::stringToWString(texturePath.string()) << std::endl;
 						result.setMaterial(std::make_unique<spk::Image>(texturePath));
 						break;
 					}
 				}
+			}
+			else
+			{
+				spk::cout << L"[ObjMesh] Failed to open MTL file " << spk::StringUtils::stringToWString(mtlPath.string()) << std::endl;
 			}
 		}
 

--- a/src/structure/engine/spk_obj_mesh_renderer.cpp
+++ b/src/structure/engine/spk_obj_mesh_renderer.cpp
@@ -2,6 +2,7 @@
 #include "structure/container/spk_json_object.hpp"
 #include "structure/math/spk_matrix.hpp"
 
+#include "spk_debug_macro.hpp"
 #include "spk_generated_resources.hpp"
 #include "structure/engine/spk_entity.hpp"
 
@@ -131,6 +132,7 @@ void main()
 
 	void ObjMeshRenderer::setTexture(spk::SafePointer<const spk::Texture> p_texture)
 	{
+		spk::cout << L"[ObjMeshRenderer] setTexture(" << p_texture << L")" << std::endl;
 		_painter.setTexture(p_texture);
 	}
 
@@ -147,7 +149,15 @@ void main()
 		if (_mesh != nullptr)
 		{
 			_painter.prepare(*_mesh);
-			_painter.setTexture(_mesh->material());
+			if (_painter.texture() == nullptr)
+			{
+				spk::cout << L"[ObjMeshRenderer] using mesh material texture" << std::endl;
+				_painter.setTexture(_mesh->material());
+			}
+			else
+			{
+				spk::cout << L"[ObjMeshRenderer] keeping existing texture" << std::endl;
+			}
 		}
 		_painter.validate();
 	}


### PR DESCRIPTION
## Summary
- Avoid overriding an explicitly set texture when assigning a mesh
- Log texture changes in ObjMeshRenderer
- Add OBJ and material loading debug output

## Testing
- `cmake --preset test-debug` *(fails: Could not find toolchain file C:/vcpkg/scripts/buildsystems/vcpkg.cmake and Ninja not found)*
- `clang-tidy src/structure/engine/spk_obj_mesh_renderer.cpp src/structure/engine/spk_obj_mesh.cpp -p build/test-debug` *(fails: Could not auto-detect compilation database)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(fails: No tests were found)

------
https://chatgpt.com/codex/tasks/task_e_68a7830df794832580c312d73c51de67