### PR TITLE
Add material change contract for ObjMesh

### DIFF
--- a/include/structure/engine/spk_obj_mesh.hpp
+++ b/include/structure/engine/spk_obj_mesh.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 
+#include "structure/design_pattern/spk_contract_provider.hpp"
 #include "structure/engine/spk_mesh.hpp"
 #include "structure/engine/spk_vertex.hpp"
 #include "structure/graphics/texture/spk_texture.hpp"
@@ -15,10 +16,15 @@ namespace spk
 	{
 	private:
 		std::unique_ptr<spk::Texture> _material;
+		mutable spk::TContractProvider<spk::SafePointer<spk::Texture>> _onMaterialChangeProvider;
 
 	public:
+		using MaterialChangeContract = spk::TContractProvider<spk::SafePointer<spk::Texture>>::Contract;
+		using MaterialChangeJob = spk::TContractProvider<spk::SafePointer<spk::Texture>>::Job;
+
 		ObjMesh() = default;
 
+		MaterialChangeContract onMaterialChange(const MaterialChangeJob &p_job) const;
 		void setMaterial(std::unique_ptr<spk::Texture> p_material);
 		spk::SafePointer<const spk::Texture> material() const;
 

--- a/include/structure/engine/spk_obj_mesh_renderer.hpp
+++ b/include/structure/engine/spk_obj_mesh_renderer.hpp
@@ -41,6 +41,7 @@ namespace spk
 	private:
 		spk::SafePointer<const spk::ObjMesh> _mesh;
 		Painter _painter;
+		spk::ObjMesh::MaterialChangeContract _onMeshMaterialChangeContract;
 		spk::ContractProvider::Contract _onOwnerTransformEditionContract;
 
 	public:

--- a/src/structure/engine/spk_obj_mesh.cpp
+++ b/src/structure/engine/spk_obj_mesh.cpp
@@ -70,11 +70,17 @@ namespace spk
 	void ObjMesh::setMaterial(std::unique_ptr<spk::Texture> p_material)
 	{
 		_material = std::move(p_material);
+		_onMaterialChangeProvider.trigger(spk::SafePointer<spk::Texture>(_material.get()));
 	}
 
 	spk::SafePointer<const spk::Texture> ObjMesh::material() const
 	{
 		return (spk::SafePointer<const spk::Texture>(_material.get()));
+	}
+
+	ObjMesh::MaterialChangeContract ObjMesh::onMaterialChange(const MaterialChangeJob &p_job) const
+	{
+		return (_onMaterialChangeProvider.subscribe(p_job));
 	}
 
 	void ObjMesh::applyOffset(const spk::Vector3 &p_offset)

--- a/src/structure/engine/spk_obj_mesh_renderer.cpp
+++ b/src/structure/engine/spk_obj_mesh_renderer.cpp
@@ -144,20 +144,14 @@ void main()
 	void ObjMeshRenderer::setMesh(const spk::SafePointer<const spk::ObjMesh> &p_mesh)
 	{
 		_mesh = p_mesh;
+		_onMeshMaterialChangeContract = spk::ObjMesh::MaterialChangeContract();
 
 		_painter.clear();
 		if (_mesh != nullptr)
 		{
+			_onMeshMaterialChangeContract = _mesh->onMaterialChange([this](spk::SafePointer<spk::Texture> p_texture) { setTexture(p_texture); });
 			_painter.prepare(*_mesh);
-			if (_painter.texture() == nullptr)
-			{
-				spk::cout << L"[ObjMeshRenderer] using mesh material texture" << std::endl;
-				_painter.setTexture(_mesh->material());
-			}
-			else
-			{
-				spk::cout << L"[ObjMeshRenderer] keeping existing texture" << std::endl;
-			}
+			setTexture(_mesh->material());
 		}
 		_painter.validate();
 	}


### PR DESCRIPTION
## Summary
- Add onMaterialChange contract provider in ObjMesh to notify texture updates
- Subscribe ObjMeshRenderer to mesh material updates and remove texture caching
- Ensure each ObjMesh stores its own material

## Testing
- `cmake --preset test-debug` *(fails: Could not find toolchain file: C:/vcpkg/scripts/buildsystems/vcpkg.cmake)*
- `clang-tidy include/structure/engine/spk_obj_mesh.hpp src/structure/engine/spk_obj_mesh.cpp include/structure/engine/spk_obj_mesh_renderer.hpp src/structure/engine/spk_obj_mesh_renderer.cpp -p build/test-debug` *(fails: Could not auto-detect compilation database)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7860170188325892d2e098fad0c75