### PR TITLE
Cache OBJ materials globally

### DIFF
--- a/include/structure/engine/spk_obj_mesh.hpp
+++ b/include/structure/engine/spk_obj_mesh.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <filesystem>
-#include <memory>
 #include <string>
+#include <unordered_map>
 
 #include "structure/design_pattern/spk_contract_provider.hpp"
 #include "structure/engine/spk_mesh.hpp"
@@ -15,7 +15,8 @@ namespace spk
 	class ObjMesh : public TMesh<Vertex>
 	{
 	private:
-		std::unique_ptr<spk::Texture> _material;
+		static inline std::unordered_map<std::filesystem::path, spk::Texture> _materials;
+		std::filesystem::path _materialPath;
 		mutable spk::TContractProvider<spk::SafePointer<spk::Texture>> _onMaterialChangeProvider;
 
 	public:
@@ -25,7 +26,7 @@ namespace spk
 		ObjMesh() = default;
 
 		MaterialChangeContract onMaterialChange(const MaterialChangeJob &p_job) const;
-		void setMaterial(std::unique_ptr<spk::Texture> p_material);
+		void setMaterial(const std::filesystem::path &p_materialPath);
 		spk::SafePointer<const spk::Texture> material() const;
 
 		void applyOffset(const spk::Vector3 &p_offset);


### PR DESCRIPTION
## Summary
- cache OBJ materials in a static map keyed by file path
- load materials from MTL files when present

## Testing
- `cmake --preset test-debug` (fails: Could not find toolchain file)
- `clang-tidy include/structure/engine/spk_obj_mesh.hpp src/structure/engine/spk_obj_mesh.cpp -p build/test-debug` (fails: Could not auto-detect compilation database)
- `cmake --build --preset test-debug` (fails: No such file or directory)
- `ctest --preset test-debug`

------
https://chatgpt.com/codex/tasks/task_e_68a7900f05208325af0630525e100ff6