### PR TITLE
Flip UVs for upside-down blocks

### DIFF
--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -243,6 +243,10 @@ private:
 			for (auto &v : p_vertices)
 			{
 				v.position = _applyOrientation(v.position, p_orientation);
+				if ((p_orientation.verticalOrientation == VerticalOrientation::YNegative) && (v.uv != -1))
+				{
+					v.uv.y = 1.0f - v.uv.y;
+				}
 			}
 			if (p_orientation.verticalOrientation == VerticalOrientation::YNegative)
 			{


### PR DESCRIPTION
## Summary
- Flip UV coordinates when a block is placed with YNegative orientation

## Testing
- `clang-format -i playground/src/main.cpp`
- `clang-tidy playground/src/main.cpp -- -std=c++20` (fails: 2921 warnings and 1 error)
- `cmake --preset test-debug` (fails: could not find toolchain file C:/vcpkg/scripts/buildsystems/vcpkg.cmake and missing Ninja)
- `cmake --build --preset test-debug` (fails: No such file or directory)
- `ctest --preset test-debug` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a7b002239883259daf0721182d4b21