### PR TITLE
Mirror sprite UVs within vertical range

### DIFF
--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -240,17 +240,35 @@ private:
 
 		static void _applyOrientationToVertices(std::vector<spk::Vertex> &p_vertices, const Orientation &p_orientation)
 		{
-			for (auto &v : p_vertices)
-			{
-				v.position = _applyOrientation(v.position, p_orientation);
-				if ((p_orientation.verticalOrientation == VerticalOrientation::YNegative) && (v.uv != -1))
-				{
-					v.uv.y = 1.0f - v.uv.y;
-				}
-			}
 			if (p_orientation.verticalOrientation == VerticalOrientation::YNegative)
 			{
+				float minY = std::numeric_limits<float>::max();
+				float maxY = std::numeric_limits<float>::lowest();
+
+				for (const auto &v : p_vertices)
+				{
+					if (v.uv != -1)
+					{
+						minY = std::min(minY, v.uv.y);
+						maxY = std::max(maxY, v.uv.y);
+					}
+				}
+				for (auto &v : p_vertices)
+				{
+					v.position = _applyOrientation(v.position, p_orientation);
+					if (v.uv != -1)
+					{
+						v.uv.y = minY + maxY - v.uv.y;
+					}
+				}
 				std::reverse(p_vertices.begin(), p_vertices.end());
+			}
+			else
+			{
+				for (auto &v : p_vertices)
+				{
+					v.position = _applyOrientation(v.position, p_orientation);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Mirror vertical UVs between their min and max values when orientation is flipped, fixing sprites that occupy only part of the texture.

## Testing
- `clang-tidy playground/src/main.cpp -- -std=c++20` (2921 warnings, 1 error)
- `cmake --preset test-debug` (failed: could not find vcpkg toolchain file)
- `cmake --build --preset test-debug` (failed: build.ninja missing)
- `ctest --preset test-debug` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a7b2e230d48325a188ede81687d346