### PR TITLE
Use Polygon::pointsRef in collectTriangles

### DIFF
--- a/src/structure/engine/spk_rigid_body.cpp
+++ b/src/structure/engine/spk_rigid_body.cpp
@@ -237,12 +237,13 @@ namespace spk
 				for (const auto &poly : collider->polygons())
 				{
 					auto tris = poly.triangulize();
-					for (auto &tri : tris)
+					for (const auto &tri : tris)
 					{
-						tri.points[0] = p_transform * tri.points[0];
-						tri.points[1] = p_transform * tri.points[1];
-						tri.points[2] = p_transform * tri.points[2];
-						result.push_back({tri.points[0], tri.points[1], tri.points[2]});
+						const auto &pts = tri.pointsRef();
+						spk::Vector3 p0 = p_transform * pts[0];
+						spk::Vector3 p1 = p_transform * pts[1];
+						spk::Vector3 p2 = p_transform * pts[2];
+						result.push_back({p0, p1, p2});
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- Fix `collectTriangles` to access polygon vertices through `pointsRef` instead of nonexistent `points` member

## Testing
- `clang-tidy src/structure/engine/spk_rigid_body.cpp -- -Iinclude -std=gnu++20` *(fails: 'GL/glew.h' file not found)*
- `cmake --preset test-debug` *(fails: Could not find toolchain file: C:/vcpkg/scripts/buildsystems/vcpkg.cmake; Ninja not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab292efb788325b4c82d743544f808