### PR TITLE
Add polygon containment and fix face footprint handling

### DIFF
--- a/include/structure/math/spk_polygon.hpp
+++ b/include/structure/math/spk_polygon.hpp
@@ -14,6 +14,7 @@ namespace spk
 		static bool _approxEq(float p_a, float p_b, float p_tol);
 		static bool _inRange(float p_x, float p_a, float p_b, float p_tol);
 		static bool _pointOnSegment2D(const spk::Vector2 &p_p, const spk::Vector2 &p_a, const spk::Vector2 &p_b, float p_tol);
+		static bool _pointInPolygon2D(const spk::Vector2 &p_point, const std::vector<spk::Vector2> &p_polygon, float p_tol);
 
 		std::unordered_map<spk::Vector3, std::vector<spk::Vector3>> _edges;
 		std::vector<spk::Vector3> _points;
@@ -27,6 +28,7 @@ namespace spk
 		std::vector<spk::Vector3> rewind() const;
 
 		bool canInsert(const Polygon &p_polygon) const;
+		bool contains(const Polygon &p_polygon) const;
 		void addTriangle(const spk::Vector3 &p_a, const spk::Vector3 &p_b, const spk::Vector3 &p_c);
 		void addQuad(const spk::Vector3 &p_a, const spk::Vector3 &p_b, const spk::Vector3 &p_c, const spk::Vector3 &p_d);
 		void addPolygon(const Polygon &p_polygon);

--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -347,9 +347,13 @@ private:
 				if (_isAxisAlignedFace(vertices, normal))
 				{
 					Face &face = result.faces[normal];
-					for (auto &v : vertices)
+					if (vertices.size() == 3)
 					{
-						face.footprint.points().push_back(v.position);
+						face.footprint.addTriangle(vertices[0].position, vertices[1].position, vertices[2].position);
+					}
+					else
+					{
+						face.footprint.addQuad(vertices[0].position, vertices[1].position, vertices[2].position, vertices[3].position);
 					}
 					_addVerticesToMesh(face.mesh, vertices);
 


### PR DESCRIPTION
## Summary
- Add internal 2D point-in-polygon helper and expose Polygon::contains to check if one polygon fully encloses another
- Build face footprints using addTriangle/addQuad instead of modifying polygon points directly

## Testing
- `clang-tidy playground/src/main.cpp include/structure/math/spk_polygon.hpp src/structure/math/spk_polygon.cpp -- -std=c++20` *(fails: 'structure/math/spk_plane.hpp' file not found)*
- `cmake --preset test-debug` *(fails: Could not find toolchain file: C:/vcpkg/scripts/buildsystems/vcpkg.cmake)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2c5158f083259797527f2d013bb3