### PR TITLE
merge collision faces and restore occlusion

### DIFF
--- a/checker/src/structure/math/spk_polygon_tester.cpp
+++ b/checker/src/structure/math/spk_polygon_tester.cpp
@@ -2,74 +2,63 @@
 
 TEST_F(PolygonTest, ContainsInside)
 {
-	spk::Polygon outer;
-	outer.points = { {0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f} };
-	
-	spk::Polygon inner;
-	inner.points = { {0.2f, 0.2f, 0.0f}, {0.8f, 0.2f, 0.0f}, {0.8f, 0.8f, 0.0f}, {0.2f, 0.8f, 0.0f} };
-	
+	spk::Polygon outer = spk::Polygon::makeSquare({0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f});
+
+	spk::Polygon inner = spk::Polygon::makeSquare({0.2f, 0.2f, 0.0f}, {0.8f, 0.2f, 0.0f}, {0.8f, 0.8f, 0.0f}, {0.2f, 0.8f, 0.0f});
+
 	EXPECT_TRUE(outer.contains(inner));
 }
 
 TEST_F(PolygonTest, ContainsSharedEdge)
 {
-	spk::Polygon outer;
-	outer.points = { {0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f} };
-	
-	spk::Polygon same;
-	same.points = outer.points;
-	
+	spk::Polygon outer = spk::Polygon::makeSquare({0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f});
+
+	spk::Polygon same = outer;
+
 	EXPECT_TRUE(outer.contains(same));
 }
 
 TEST_F(PolygonTest, ContainsOutside)
 {
-        spk::Polygon outer;
-        outer.points = { {0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f} };
+	spk::Polygon outer = spk::Polygon::makeSquare({0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f});
 
-        spk::Polygon outside;
-        outside.points = { {-0.1f, 0.2f, 0.0f}, {1.1f, 0.2f, 0.0f}, {1.1f, 0.8f, 0.0f}, {-0.1f, 0.8f, 0.0f} };
+	spk::Polygon outside = spk::Polygon::makeSquare({-0.1f, 0.2f, 0.0f}, {1.1f, 0.2f, 0.0f}, {1.1f, 0.8f, 0.0f}, {-0.1f, 0.8f, 0.0f});
 
-        EXPECT_FALSE(outer.contains(outside));
+	EXPECT_FALSE(outer.contains(outside));
 }
 
 TEST_F(PolygonTest, ContainPointInside)
 {
-        spk::Polygon poly;
-        poly.points = { {0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f} };
+	spk::Polygon poly = spk::Polygon::makeSquare({0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f});
 
-        spk::Vector3 point(0.5f, 0.5f, 0.0f);
+	spk::Vector3 point(0.5f, 0.5f, 0.0f);
 
-        EXPECT_TRUE(poly.contains(point));
+	EXPECT_TRUE(poly.contains(point));
 }
 
 TEST_F(PolygonTest, ContainPointEdge)
 {
-        spk::Polygon poly;
-        poly.points = { {0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f} };
+	spk::Polygon poly = spk::Polygon::makeSquare({0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f});
 
-        spk::Vector3 edgePoint(0.0f, 0.5f, 0.0f);
+	spk::Vector3 edgePoint(0.0f, 0.5f, 0.0f);
 
-        EXPECT_TRUE(poly.contains(edgePoint));
+	EXPECT_TRUE(poly.contains(edgePoint));
 }
 
 TEST_F(PolygonTest, ContainPointOutside)
 {
-        spk::Polygon poly;
-        poly.points = { {0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f} };
+	spk::Polygon poly = spk::Polygon::makeSquare({0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f});
 
-        spk::Vector3 outsidePoint(-0.1f, 0.5f, 0.0f);
+	spk::Vector3 outsidePoint(-0.1f, 0.5f, 0.0f);
 
-        EXPECT_FALSE(poly.contains(outsidePoint));
+	EXPECT_FALSE(poly.contains(outsidePoint));
 }
 
 TEST_F(PolygonTest, ContainPointOffPlane)
 {
-        spk::Polygon poly;
-        poly.points = { {0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f} };
+	spk::Polygon poly = spk::Polygon::makeSquare({0.0f, 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f}, {1.0f, 1.0f, 0.0f}, {0.0f, 1.0f, 0.0f});
 
-        spk::Vector3 above(0.5f, 0.5f, 0.1f);
+	spk::Vector3 above(0.5f, 0.5f, 0.1f);
 
-        EXPECT_FALSE(poly.contains(above));
+	EXPECT_FALSE(poly.contains(above));
 }
-

--- a/include/structure/math/spk_edge.hpp
+++ b/include/structure/math/spk_edge.hpp
@@ -1,23 +1,42 @@
 #pragma once
 
 #include "structure/math/spk_vector3.hpp"
+#include <ostream>
 
 namespace spk
 {
-	struct Edge
+	class Edge
 	{
-		spk::Vector3 first;
-		spk::Vector3 second;
+	private:
+		spk::Vector3 _first;
+		spk::Vector3 _second;
+		spk::Vector3 _delta;
+		spk::Vector3 _direction;
 
+	public:
 		Edge() = default;
 		Edge(const spk::Vector3 &p_first, const spk::Vector3 &p_second);
 
-		Edge inverse() const;
+		const spk::Vector3 &first() const;
+		const spk::Vector3 &second() const;
+		const spk::Vector3 &delta() const;
+		const spk::Vector3 &direction() const;
+
+		float orientation(const spk::Vector3 &p_point, const spk::Vector3 &p_normal) const;
+		bool contains(const spk::Vector3 &p_point, bool p_checkAlignment = true) const;
+		float project(const spk::Vector3 &p_point) const;
+
 		bool isInverse(const Edge &p_other) const;
+		Edge inverse() const;
+		bool isParallel(const Edge &p_other) const;
+		bool isColinear(const Edge &p_other) const;
 		bool colinear(const Edge &p_other) const;
 
 		bool operator==(const Edge &p_other) const;
 		bool operator<(const Edge &p_other) const;
+
+		friend std::ostream &operator<<(std::ostream &p_os, const Edge &p_edge);
+		friend std::wostream &operator<<(std::wostream &p_wos, const Edge &p_edge);
 	};
 }
 

--- a/include/structure/math/spk_plane.hpp
+++ b/include/structure/math/spk_plane.hpp
@@ -21,7 +21,7 @@ namespace spk
 		bool contains(const spk::Polygon &p_polygon) const
 		{
 			const float eps = 1e-5f;
-			for (const spk::Vector3 &point : p_polygon.points)
+			for (const spk::Vector3 &point : p_polygon.points())
 			{
 				if (std::abs(normal.dot(point - origin)) > eps)
 				{

--- a/include/structure/math/spk_polygon.hpp
+++ b/include/structure/math/spk_polygon.hpp
@@ -9,15 +9,19 @@ namespace spk
 	class Polygon
 	{
 	private:
-		std::vector<spk::Edge> _edges;
+		mutable std::vector<spk::Edge> _edges;
+		std::vector<spk::Vector3> _points;
+		mutable bool _edgesDirty = false;
 
 		void _addEdge(const spk::Vector3 &p_a, const spk::Vector3 &p_b);
+		void _updateEdges() const;
 		static bool _edgesIntersect(const spk::Edge &p_a, const spk::Edge &p_b, const spk::Vector3 &p_normal, float p_eps);
 		static bool _isPointInside(const Polygon &p_poly, const spk::Vector3 &p_point, float p_eps);
 
 	public:
 		const std::vector<spk::Edge> &edges() const;
-		std::vector<spk::Vector3> points() const;
+		const std::vector<spk::Vector3> &points() const;
+		std::vector<spk::Vector3> &points();
 
 		bool isPlanar() const;
 		spk::Vector3 normal() const;

--- a/include/structure/math/spk_polygon.hpp
+++ b/include/structure/math/spk_polygon.hpp
@@ -1,218 +1,39 @@
 #pragma once
 
-#include "structure/math/spk_vector2.hpp"
-#include "structure/math/spk_vector3.hpp"
-#include <algorithm>
-#include <cmath>
+#include "structure/math/spk_edge.hpp"
+#include <ostream>
 #include <vector>
-
-#include "spk_constants.hpp"
-#include "spk_debug_macro.hpp"
 
 namespace spk
 {
-	struct Polygon
+	class Polygon
 	{
 	private:
-		static float _polyScale(const std::vector<spk::Vector3> &ps)
-		{
-			float m = 0.f;
-			for (size_t i = 1; i < ps.size(); ++i)
-			{
-				m = std::max(m, (ps[i] - ps[i - 1]).norm());
-			}
-			return (m > 0.f ? m : 1.f);
-		}
+		std::vector<spk::Edge> _edges;
 
-		static bool _approxEq(float a, float b, float tol)
-		{
-			return std::fabs(a - b) <= tol;
-		}
-
-		static bool _inRange(float x, float a, float b, float tol)
-		{
-			const float lo = std::min(a, b) - tol;
-			const float hi = std::max(a, b) + tol;
-			return (x >= lo && x <= hi);
-		}
-
-		static bool _pointOnSegment2D(const spk::Vector2 &P, const spk::Vector2 &A, const spk::Vector2 &B, float tol)
-		{
-			// Collinearity via cross, then projection within segment via dot
-			const spk::Vector2 AB = B - A;
-			const spk::Vector2 AP = P - A;
-			const float cross = AB.x * AP.y - AB.y * AP.x;
-			if (std::fabs(cross) > tol)
-			{
-				return false;
-			}
-
-			const float dot = AP.x * AB.x + AP.y * AB.y;
-			if (dot < -tol)
-			{
-				return false;
-			}
-
-			const float len2 = AB.x * AB.x + AB.y * AB.y;
-			if (dot > len2 + tol)
-			{
-				return false;
-			}
-
-			return true;
-		}
+		void _addEdge(const spk::Vector3 &p_a, const spk::Vector3 &p_b);
+		static bool _edgesIntersect(const spk::Edge &p_a, const spk::Edge &p_b, const spk::Vector3 &p_normal, float p_eps);
+		static bool _isPointInside(const Polygon &p_poly, const spk::Vector3 &p_point, float p_eps);
 
 	public:
-		std::vector<spk::Vector3> points;
+		const std::vector<spk::Edge> &edges() const;
+		std::vector<spk::Vector3> points() const;
 
-		spk::Vector3 normal() const
-		{
-			if (points.size() < 3)
-			{
-				GENERATE_ERROR("Can't generate normal on a polygon with less than 3 points");
-			}
-			const spk::Vector3 &origin = points[0];
-			spk::Vector3 normal = (points[1] - origin).cross(points[2] - origin);
-			return (normal.normalize());
-		}
+		bool isPlanar() const;
+		spk::Vector3 normal() const;
+		bool isCoplanar(const Polygon &p_other) const;
+		bool isAdjacent(const Polygon &p_other) const;
+		bool isConvex(float p_eps = 1e-6f, bool p_strictly = false) const;
+		bool isOverlapping(const Polygon &p_other) const;
+		bool contains(const spk::Vector3 &p_point) const;
+		bool contains(const Polygon &p_polygon) const;
+		Polygon fuze(const Polygon &p_other) const;
 
-		bool isPlanar() const
-		{
-			if (points.size() < 4)
-			{
-				return true;
-			}
-			const float tol = 1e-6f * _polyScale(points);
+		static Polygon fromLoop(const std::vector<spk::Vector3> &p_vs);
+		static Polygon makeTri(const spk::Vector3 &p_a, const spk::Vector3 &p_b, const spk::Vector3 &p_c);
+		static Polygon makeSquare(const spk::Vector3 &p_a, const spk::Vector3 &p_b, const spk::Vector3 &p_c, const spk::Vector3 &p_d);
 
-			const spk::Vector3 &origin = points[0];
-			spk::Vector3 n = normal();
-			for (size_t i = 1; i < points.size(); ++i)
-			{
-				if (std::fabs(n.dot(points[i] - origin)) > tol)
-				{
-					return false;
-				}
-			}
-			return true;
-		}
-
-		bool isCoplanar(const Polygon &p_polygon) const
-		{
-			if (isPlanar() == false || p_polygon.isPlanar() == false)
-			{
-				return false;
-			}
-
-			spk::Vector3 n = normal();
-			spk::Vector3 otherNormal = p_polygon.normal();
-
-			bool sameNormal = n == otherNormal;
-			bool oppositeNormal = n == -otherNormal;
-
-			if (sameNormal == false && oppositeNormal == false)
-			{
-				return false;
-			}
-
-			const spk::Vector3 &origin = points[0];
-			float distance = n.dot(p_polygon.points[0] - origin);
-			bool result = std::abs(distance) <= spk::Constants::pointPrecision;
-			return result;
-		}
-
-		bool contains(const spk::Vector3 &p_point) const
-		{
-			if (points.size() < 3)
-			{
-				return false;
-			}
-
-			const float scale = _polyScale(points);
-			const float tol3D = 1e-6f * scale;
-			const float tol2D = 1e-6f * std::max(1.0f, scale);
-
-			const spk::Vector3 &origin = points[0];
-			spk::Vector3 u = (points[1] - origin).normalize();
-			spk::Vector3 normal = (points[1] - origin).cross(points[2] - origin).normalize();
-			spk::Vector3 v = normal.cross(u);
-
-			float distance = normal.dot(p_point - origin);
-			if (std::fabs(distance) > tol3D)
-			{
-				return false;
-			}
-
-			auto project = [&](const spk::Vector3 &P)
-			{
-				spk::Vector3 rel = P - origin;
-				return spk::Vector2(rel.dot(u), rel.dot(v));
-			};
-
-			std::vector<spk::Vector2> poly2d;
-			poly2d.reserve(points.size());
-			for (const spk::Vector3 &pt : points)
-			{
-				poly2d.push_back(project(pt));
-			}
-
-			const spk::Vector2 p = project(p_point);
-
-			for (size_t i = 0, j = poly2d.size() - 1; i < poly2d.size(); j = i++)
-			{
-				if (_pointOnSegment2D(p, poly2d[j], poly2d[i], tol2D))
-				{
-					return true;
-				}
-			}
-
-			// Tolerant ray casting (avoid vertex double-count with slight y-nudge)
-			bool inside = false;
-			const float py = p.y - tol2D;
-
-			for (size_t i = 0, j = poly2d.size() - 1; i < poly2d.size(); j = i++)
-			{
-				const spk::Vector2 &A = poly2d[j];
-				const spk::Vector2 &B = poly2d[i];
-
-				const bool aboveA = (A.y > py);
-				const bool aboveB = (B.y > py);
-
-				if (aboveA != aboveB)
-				{
-					float xIntersect = (B.x - A.x) * (py - A.y) / (B.y - A.y) + A.x;
-
-					if (std::fabs(xIntersect - p.x) <= tol2D)
-					{
-						return true;
-					}
-					if (p.x < xIntersect)
-					{
-						inside = !inside;
-					}
-				}
-			}
-
-			return inside;
-		}
-
-		bool contains(const Polygon &p_polygon) const
-		{
-			if (isCoplanar(p_polygon) == false)
-			{
-				return false;
-			}
-
-			// For full containment, every vertex of the inner polygon must be inside or on the boundary.
-			for (const spk::Vector3 &pt : p_polygon.points)
-			{
-				bool inside = contains(pt);
-				if (inside == false)
-				{
-					return false;
-				}
-			}
-
-			return true;
-		}
+		friend std::ostream &operator<<(std::ostream &p_os, const Polygon &p_poly);
+		friend std::wostream &operator<<(std::wostream &p_wos, const Polygon &p_poly);
 	};
 }

--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -1,883 +1,1339 @@
-#include "structure/math/spk_constants.hpp"
-#include "structure/math/spk_vector2.hpp"
-#include "structure/math/spk_vector3.hpp"
-#include "structure/math/spk_vector4.hpp"
+#include "structure/math/spk_plane.hpp"
+#include "structure/math/spk_polygon.hpp"
 #include <algorithm>
 #include <array>
 #include <cmath>
 #include <iostream>
 #include <limits>
 #include <map>
-#include <utility>
+#include <memory>
+#include <sparkle.hpp>
+#include <type_traits>
+#include <unordered_map>
+#include <variant>
 #include <vector>
 
-namespace tmp
+class Block
 {
-	class Edge
+public:
+	using ID = short;
+
+	enum class HorizontalOrientation
 	{
-	private:
-		spk::Vector3 _first;
-		spk::Vector3 _second;
+		XPositive,
+		ZPositive,
+		XNegative,
+		ZNegative
+	};
 
-		spk::Vector3 _delta;
-		spk::Vector3 _direction;
+	enum class VerticalOrientation
+	{
+		YPositive,
+		YNegative
+	};
 
-	public:
-		Edge(const spk::Vector3 &p_first, const spk::Vector3 &p_second) :
-			_first(p_first),
-			_second(p_second)
+	struct Orientation
+	{
+		HorizontalOrientation horizontalOrientation;
+		VerticalOrientation verticalOrientation;
+
+		bool operator<(const Orientation &p_other) const
 		{
-			if (_second == _first)
+			if (horizontalOrientation != p_other.horizontalOrientation)
 			{
-				GENERATE_ERROR("Can't create an edge of lenght == 0");
+				return horizontalOrientation < p_other.horizontalOrientation;
 			}
-
-			_delta = (_second - _first);
-			_direction = _delta.normalize();
-		}
-
-		const spk::Vector3 &first() const
-		{
-			return (_first);
-		}
-
-		const spk::Vector3 &second() const
-		{
-			return (_second);
-		}
-
-		const spk::Vector3 &delta() const
-		{
-			return (_delta);
-		}
-
-		const spk::Vector3 &direction() const
-		{
-			return (_direction);
-		}
-
-		float orientation(const spk::Vector3 &p_point, const spk::Vector3 &p_normal) const
-		{
-			return ((_second - _first).cross(p_point - _first)).dot(p_normal);
-		}
-
-		bool contains(const spk::Vector3 &p_point, bool p_checkAlignment = true) const
-		{
-			if (p_point == _first)
-			{
-				return (true);
-			}
-			const spk::Vector3 v = p_point - _first;
-
-			if (p_checkAlignment == true && v.normalize() != _direction)
-			{
-				return (false);
-			}
-
-			const float t = v.dot(_direction);
-
-			const float len = (_second - _first).dot(_direction);
-
-			return (t >= 0) && (t <= len);
-		}
-
-		float project(const spk::Vector3 &p_point) const
-		{
-			return (_delta.dot(p_point - _first));
-		}
-
-		bool isInverse(const Edge &p_other) const
-		{
-			return (_first == p_other.second() && _second == p_other.first());
-		}
-
-		Edge inverse() const
-		{
-			return (Edge(_second, _first));
-		}
-
-		bool isParallel(const Edge &p_other) const
-		{
-			return (direction() == p_other.direction() || direction() == p_other.direction().inverse());
-		}
-
-		bool isColinear(const Edge &p_other) const
-		{
-			if (isParallel(p_other) == false)
-			{
-				return (false);
-			}
-
-			spk::Vector3 delta = (p_other._first - _first);
-
-			if (delta == spk::Vector3(0, 0, 0))
-			{
-				return (true);
-			}
-
-			return (std::fabs(delta.normalize().dot(_direction)) == 1);
-		}
-
-		bool operator==(const Edge &p_other) const
-		{
-			return (first() == p_other.first()) && (second() == p_other.second());
-		}
-
-		bool isSame(const Edge &p_other) const
-		{
-			return ((first() == p_other.first()) && (second() == p_other.second()) || (first() == p_other.second()) && (second() == p_other.first()));
-		}
-
-		bool operator<(const Edge &p_other) const
-		{
-			if (first() != p_other.first())
-			{
-				return (first() < p_other.first());
-			}
-			return (second() < p_other.second());
-		}
-
-		friend std::ostream &operator<<(std::ostream &p_os, const Edge &p_edge)
-		{
-			p_os << "(" << p_edge.first() << " -> " << p_edge.second() << ")";
-			return p_os;
-		}
-
-		friend std::wostream &operator<<(std::wostream &p_wos, const Edge &p_edge)
-		{
-			p_wos << L"(" << p_edge.first() << L" -> " << p_edge.second() << L")";
-			return p_wos;
+			return verticalOrientation < p_other.verticalOrientation;
 		}
 	};
 
-	class Polygon
+	static inline const std::vector<spk::Vector3> neightbourCoordinates = {{0, 1, 0}, {0, -1, 0}, {1, 0, 0}, {0, 0, 1}, {-1, 0, 0}, {0, 0, -1}};
+
+	using Specifier = std::pair<Block::ID, Block::Orientation>;
+	using Describer = std::pair<spk::SafePointer<const Block>, Block::Orientation>;
+	using NeightbourDescriber = std::array<Block::Describer, 6>;
+	using Footprint = spk::Polygon;
+
+	static const spk::SpriteSheet &spriteSheet()
 	{
-	private:
-		std::vector<tmp::Edge> _edges;
+		return (_spriteSheet);
+	}
 
-		void _addEdge(const spk::Vector3 &p_a, const spk::Vector3 &p_b)
+	static spk::SafePointer<const spk::Texture> texture()
+	{
+		return (&_spriteSheet);
+	}
+
+protected:
+	using Type = std::wstring; // Each block type can be identified by its type : FullBlock, Slope, HalfBlock, Fence, for exemple
+	// Multiple block can shared the same type, as long as they are the same shape in 3D, with just different sprite and interaction
+
+	virtual const spk::ObjMesh &_mesh() const = 0;
+
+	static inline spk::SpriteSheet _spriteSheet = spk::SpriteSheet("playground/resources/texture/CubeTexture.png", {9, 1});
+
+	static void _applySprite(spk::ObjMesh::Shape &p_shape, const spk::SpriteSheet::Sprite &p_sprite)
+	{
+		auto transform = [&](spk::Vertex &p_v)
 		{
-			_edges.push_back(tmp::Edge(p_a, p_b));
-		}
-
-		static bool _edgesIntersect(const tmp::Edge &p_a, const tmp::Edge &p_b, const spk::Vector3 &p_normal, float p_eps)
-		{
-			float o1 = p_a.orientation(p_b.first(), p_normal);
-			float o2 = p_a.orientation(p_b.second(), p_normal);
-			float o3 = p_b.orientation(p_a.first(), p_normal);
-			float o4 = p_b.orientation(p_a.second(), p_normal);
-
-			bool cond1 = ((o1 > p_eps && o2 < -p_eps) || (o1 < -p_eps && o2 > p_eps));
-			bool cond2 = ((o3 > p_eps && o4 < -p_eps) || (o3 < -p_eps && o4 > p_eps));
-
-			return (cond1 == true && cond2 == true);
-		}
-
-		static bool _isPointInside(const Polygon &p_poly, const spk::Vector3 &p_point, float p_eps)
-		{
-			const auto &edges = p_poly.edges();
-			spk::Vector3 n = p_poly.normal();
-			float orient = edges[0].direction().cross(edges[1].direction()).dot(n);
-
-			for (size_t i = 0; i < edges.size(); i++)
+			if (p_v.uv == -1)
 			{
-				const tmp::Edge &edge = edges[i];
-				float val = edge.direction().cross(p_point - edge.first()).dot(n);
-
-				if (orient > 0)
+				return;
+			}
+			p_v.uv = (p_v.uv * p_sprite.size) + p_sprite.anchor;
+		};
+		std::visit(
+			[&](auto &p_face)
+			{
+				transform(p_face.a);
+				transform(p_face.b);
+				transform(p_face.c);
+				if constexpr (std::is_same_v<std::decay_t<decltype(p_face)>, spk::ObjMesh::Quad>)
 				{
-					if (val <= p_eps)
+					transform(p_face.d);
+				}
+			},
+			p_shape);
+	}
+
+private:
+	struct Face
+	{
+		Footprint footprint;
+		spk::ObjMesh mesh;
+		bool full = false;
+	};
+
+	class Cache
+	{
+	public:
+		struct Entry;
+
+		bool hasCase(const Orientation &p_orientation) const
+		{
+			return _cache.contains(p_orientation);
+		}
+
+		void addCase(const Orientation &p_orientation, const spk::ObjMesh &p_mesh)
+		{
+			if (_cache.contains(p_orientation) == false)
+			{
+				_cache.emplace(p_orientation, _compute(p_mesh, p_orientation));
+			}
+		}
+
+		const Entry &getCase(const Orientation &p_orientation) const
+		{
+			return _cache.at(p_orientation);
+		}
+
+		struct Entry
+		{
+			spk::ObjMesh innerMesh;
+			std::unordered_map<spk::Vector3, Face> faces;
+
+			void applyInnerMesh(spk::ObjMesh &p_target, const spk::Vector3 &p_offset) const
+			{
+				_appendMesh(p_target, innerMesh, p_offset);
+			}
+
+			void applyFace(spk::ObjMesh &p_target, const spk::Vector3 &p_offset, const spk::Vector3 &p_normal) const
+			{
+				auto it = faces.find(p_normal);
+				if (it != faces.end())
+				{
+					_appendMesh(p_target, it->second.mesh, p_offset);
+				}
+			}
+
+		private:
+			static void _appendMesh(spk::ObjMesh &p_target, const spk::ObjMesh &p_source, const spk::Vector3 &p_offset)
+			{
+				auto add = [&](auto p_shape)
+				{
+					p_shape.a.position += p_offset;
+					p_shape.b.position += p_offset;
+					p_shape.c.position += p_offset;
+					if constexpr (std::is_same_v<std::decay_t<decltype(p_shape)>, spk::ObjMesh::Quad>)
 					{
-						return (false);
+						p_shape.d.position += p_offset;
+					}
+					p_target.addShape(p_shape);
+				};
+
+				for (const auto &shape : p_source.shapes())
+				{
+					std::visit(add, shape);
+				}
+			}
+		};
+
+	private:
+		static spk::Vector3 _applyOrientation(const spk::Vector3 &p_position, const Orientation &p_orientation)
+		{
+			spk::Vector3 result = p_position - spk::Vector3(0.5f, 0.5f, 0.5f);
+			constexpr std::array<float, 4> rotations = {-90.0f, 0.0f, 90.0f, 180.0f};
+			result = result.rotate({0, rotations[static_cast<size_t>(p_orientation.horizontalOrientation)], 0});
+
+			if (p_orientation.verticalOrientation == VerticalOrientation::YNegative)
+			{
+				result.y = -result.y;
+			}
+
+			return result + spk::Vector3(0.5f, 0.5f, 0.5f);
+		}
+
+		static bool _isFullQuad(const std::vector<spk::Vertex> &p_vertices, const spk::Vector3 &p_normal)
+		{
+			if (p_vertices.size() != 4)
+			{
+				return false;
+			}
+
+			auto getAB = [&](const spk::Vector3 &p_point) -> std::pair<float, float>
+			{
+				if (std::abs(p_normal.y) > 0.0f)
+				{
+					return {p_point.x, p_point.z};
+				}
+				else if (std::abs(p_normal.x) > 0.0f)
+				{
+					return {p_point.y, p_point.z};
+				}
+				else
+				{
+					return {p_point.x, p_point.y};
+				}
+			};
+
+			float minA = std::numeric_limits<float>::max();
+			float maxA = std::numeric_limits<float>::lowest();
+			float minB = std::numeric_limits<float>::max();
+			float maxB = std::numeric_limits<float>::lowest();
+
+			for (const auto &v : p_vertices)
+			{
+				auto [a, b] = getAB(v.position);
+				minA = std::min(minA, a);
+				maxA = std::max(maxA, a);
+				minB = std::min(minB, b);
+				maxB = std::max(maxB, b);
+			}
+
+			return (
+				(std::abs(minA - 0.0f) < spk::Constants::pointPrecision) && (std::abs(maxA - 1.0f) < spk::Constants::pointPrecision) &&
+				(std::abs(minB - 0.0f) < spk::Constants::pointPrecision) && (std::abs(maxB - 1.0f) < spk::Constants::pointPrecision));
+		}
+
+		static std::vector<spk::Vertex> _extractVertices(const spk::ObjMesh::Shape &p_shape)
+		{
+			if (std::holds_alternative<spk::ObjMesh::Triangle>(p_shape))
+			{
+				const auto &tri = std::get<spk::ObjMesh::Triangle>(p_shape);
+				return {tri.a, tri.b, tri.c};
+			}
+			else
+			{
+				const auto &quad = std::get<spk::ObjMesh::Quad>(p_shape);
+				return {quad.a, quad.b, quad.c, quad.d};
+			}
+		}
+
+		static void _applyOrientationToVertices(std::vector<spk::Vertex> &p_vertices, const Orientation &p_orientation)
+		{
+			if (p_orientation.verticalOrientation == VerticalOrientation::YNegative)
+			{
+				float minY = std::numeric_limits<float>::max();
+				float maxY = std::numeric_limits<float>::lowest();
+
+				for (const auto &v : p_vertices)
+				{
+					if (v.uv != -1)
+					{
+						minY = std::min(minY, v.uv.y);
+						maxY = std::max(maxY, v.uv.y);
+					}
+				}
+				for (auto &v : p_vertices)
+				{
+					v.position = _applyOrientation(v.position, p_orientation);
+					if (v.uv != -1)
+					{
+						v.uv.y = minY + maxY - v.uv.y;
+					}
+				}
+				std::reverse(p_vertices.begin(), p_vertices.end());
+			}
+			else
+			{
+				for (auto &v : p_vertices)
+				{
+					v.position = _applyOrientation(v.position, p_orientation);
+				}
+			}
+		}
+
+		static bool _isAxisAlignedFace(const std::vector<spk::Vertex> &p_vertices, spk::Vector3 &p_outNormal)
+		{
+			auto eq = [&](float p_a, float p_b) { return std::abs(p_a - p_b) <= spk::Constants::pointPrecision; };
+
+			bool allX0 = true, allX1 = true, allY0 = true, allY1 = true, allZ0 = true, allZ1 = true;
+			for (const auto &v : p_vertices)
+			{
+				allX0 = allX0 && eq(v.position.x, 0.0f);
+				allX1 = allX1 && eq(v.position.x, 1.0f);
+				allY0 = allY0 && eq(v.position.y, 0.0f);
+				allY1 = allY1 && eq(v.position.y, 1.0f);
+				allZ0 = allZ0 && eq(v.position.z, 0.0f);
+				allZ1 = allZ1 && eq(v.position.z, 1.0f);
+			}
+
+			if (allX0)
+			{
+				p_outNormal = spk::Vector3(-1, 0, 0);
+				return true;
+			}
+			if (allX1)
+			{
+				p_outNormal = spk::Vector3(1, 0, 0);
+				return true;
+			}
+			if (allY0)
+			{
+				p_outNormal = spk::Vector3(0, -1, 0);
+				return true;
+			}
+			if (allY1)
+			{
+				p_outNormal = spk::Vector3(0, 1, 0);
+				return true;
+			}
+			if (allZ0)
+			{
+				p_outNormal = spk::Vector3(0, 0, -1);
+				return true;
+			}
+			if (allZ1)
+			{
+				p_outNormal = spk::Vector3(0, 0, 1);
+				return true;
+			}
+
+			return false;
+		}
+
+		static void _addVerticesToMesh(spk::ObjMesh &p_mesh, const std::vector<spk::Vertex> &p_vertices)
+		{
+			if (p_vertices.size() == 3)
+			{
+				p_mesh.addShape(p_vertices[0], p_vertices[1], p_vertices[2]);
+			}
+			else
+			{
+				p_mesh.addShape(p_vertices[0], p_vertices[1], p_vertices[2], p_vertices[3]);
+			}
+		}
+
+		static Entry _compute(const spk::ObjMesh &p_mesh, const Orientation &p_orientation)
+		{
+			Entry result;
+
+			for (const auto &shape : p_mesh.shapes())
+			{
+				auto vertices = _extractVertices(shape);
+				_applyOrientationToVertices(vertices, p_orientation);
+
+				spk::Vector3 normal;
+				if (_isAxisAlignedFace(vertices, normal) == true)
+				{
+					Face &face = result.faces[normal];
+					spk::Polygon current;
+					if (vertices.size() == 3)
+					{
+						current = spk::Polygon::makeTri(vertices[0].position, vertices[1].position, vertices[2].position);
+					}
+					else
+					{
+						current = spk::Polygon::makeSquare(vertices[0].position, vertices[1].position, vertices[2].position, vertices[3].position);
+					}
+
+					if (face.footprint.points().empty() == true)
+					{
+						face.footprint = current;
+					}
+					else
+					{
+						face.footprint = face.footprint.fuze(current);
+					}
+
+					_addVerticesToMesh(face.mesh, vertices);
+
+					if (vertices.size() == 4 && _isFullQuad(vertices, normal) == true)
+					{
+						face.full = true;
 					}
 				}
 				else
 				{
-					if (val >= -p_eps)
-					{
-						return (false);
-					}
+					_addVerticesToMesh(result.innerMesh, vertices);
 				}
 			}
 
-			return (true);
+			return result;
 		}
 
-	public:
-		const std::vector<tmp::Edge> edges() const
-		{
-			return (_edges);
-		}
-
-		bool isPlanar() const
-		{
-			if (_edges.size() < 2)
-			{
-				return (false);
-			}
-
-			spk::Vector3 expectedNormal = normal();
-
-			for (size_t i = 2; i < _edges.size(); i++)
-			{
-				float dot = expectedNormal.dot(_edges[i].direction());
-
-				if (dot != 0)
-				{
-					return (false);
-				}
-			}
-			return (true);
-		}
-
-		spk::Vector3 normal() const
-		{
-			if (_edges.size() < 2)
-			{
-				GENERATE_ERROR("Can't generate a normal for a polygon with less than 2 edges");
-			}
-
-			return (_edges[0].direction().cross(_edges[1].direction()));
-		}
-
-		bool isCoplanar(const Polygon &p_other) const
-		{
-			if (isPlanar() == false)
-			{
-				return (false);
-			}
-
-			if (p_other.isPlanar() == false)
-			{
-				return (false);
-			}
-
-			spk::Vector3 currentNormal = normal();
-			spk::Vector3 otherNormal = p_other.normal();
-
-			return ((currentNormal == otherNormal || currentNormal.inverse() == otherNormal) && currentNormal.dot(p_other.edges()[0].first()) == 0);
-		}
-
-		bool isAdjacent(const Polygon &p_other) const
-		{
-			if (isCoplanar(p_other) == false)
-			{
-				return (false);
-			}
-
-			for (const auto &edgeA : _edges)
-			{
-				for (const auto &edgeB : p_other.edges())
-				{
-					if (edgeA.isColinear(edgeB) == true)
-					{
-						if (edgeA.contains(edgeB.first(), false) || edgeA.contains(edgeB.second(), false) || edgeB.contains(edgeA.first(), false) ||
-							edgeB.contains(edgeA.second(), false))
-						{
-							return (true);
-						}
-					}
-				}
-			}
-			return (false);
-		}
-
-		bool isConvex(float p_eps = 1e-6f, bool p_strictly = false) const
-		{
-			if (_edges.size() < 3)
-			{
-				return (false);
-			}
-
-			spk::Vector3 polyNormal = normal();
-			float orientation = 0;
-
-			for (size_t i = 0; i < _edges.size(); i++)
-			{
-				const tmp::Edge &current = _edges[i];
-				const tmp::Edge &next = _edges[(i + 1) % _edges.size()];
-
-				float dot = current.direction().cross(next.direction()).dot(polyNormal);
-
-				if (std::fabs(dot) <= p_eps)
-				{
-					if (p_strictly == true)
-					{
-						return (false);
-					}
-					continue;
-				}
-
-				if (orientation == 0)
-				{
-					orientation = (dot > 0) ? 1.0f : -1.0f;
-				}
-				else if (((dot > 0) ? 1.0f : -1.0f) != orientation)
-				{
-					return (false);
-				}
-			}
-
-			return (orientation != 0);
-		}
-
-		bool isOverlapping(const Polygon &p_other) const
-		{
-			if (isCoplanar(p_other) == false)
-			{
-				return (false);
-			}
-
-			const float eps = 1e-6f;
-			spk::Vector3 polyNormal = normal();
-
-			for (const auto &edgeA : _edges)
-			{
-				for (const auto &edgeB : p_other.edges())
-				{
-					if (_edgesIntersect(edgeA, edgeB, polyNormal, eps) == true)
-					{
-						return (true);
-					}
-				}
-			}
-
-			if (_isPointInside(*this, p_other.edges()[0].first(), eps) == true)
-			{
-				return (true);
-			}
-
-			if (_isPointInside(p_other, _edges[0].first(), eps) == true)
-			{
-				return (true);
-			}
-
-			return (false);
-		}
-
-		Polygon fuze(const Polygon &p_other) const;
-
-		static Polygon fromLoop(const std::vector<spk::Vector3> &p_vs)
-		{
-			Polygon r;
-			if (p_vs.size() < 2)
-			{
-				return r;
-			}
-			for (size_t i = 1; i < p_vs.size(); ++i)
-			{
-				r._addEdge(p_vs[i - 1], p_vs[i]);
-			}
-			return r;
-		}
-
-		static Polygon makeTriangle(const spk::Vector3 &p_a, const spk::Vector3 &p_b, const spk::Vector3 &p_c)
-		{
-			Polygon result;
-
-			result._addEdge(p_a, p_b);
-			result._addEdge(p_b, p_c);
-			result._addEdge(p_c, p_a);
-
-			return (result);
-		}
-
-		static Polygon makeSquare(const spk::Vector3 &p_a, const spk::Vector3 &p_b, const spk::Vector3 &p_c, const spk::Vector3 &p_d)
-		{
-			Polygon result;
-
-			result._addEdge(p_a, p_b);
-			result._addEdge(p_b, p_c);
-			result._addEdge(p_c, p_d);
-			result._addEdge(p_d, p_a);
-
-			return (result);
-		}
-
-		friend std::ostream &operator<<(std::ostream &p_os, const Polygon &p_poly)
-		{
-			p_os << "{";
-			for (size_t i = 0; i < p_poly._edges.size(); i++)
-			{
-				p_os << p_poly._edges[i];
-				if (i + 1 < p_poly._edges.size())
-				{
-					p_os << ", ";
-				}
-			}
-			p_os << "}";
-			return p_os;
-		}
-
-		friend std::wostream &operator<<(std::wostream &p_wos, const Polygon &p_poly)
-		{
-			p_wos << L"{";
-			for (size_t i = 0; i < p_poly._edges.size(); i++)
-			{
-				p_wos << p_poly._edges[i];
-				if (i + 1 < p_poly._edges.size())
-				{
-					p_wos << L", ";
-				}
-			}
-			p_wos << L"}";
-			return p_wos;
-		}
+		std::map<Orientation, Entry> _cache;
 	};
-}
 
-namespace
-{
-	// Clamp a float in [min,max]
-	float clampf(float p_v, float p_lo, float p_hi)
+	mutable Cache _cache;
+
+	const Cache::Entry &_ensureCacheCase(const Orientation &p_orientation) const
 	{
-		return std::max(p_lo, std::min(p_v, p_hi));
+		if (_cache.hasCase(p_orientation) == false)
+		{
+			_cache.addCase(p_orientation, _mesh());
+		}
+		return _cache.getCase(p_orientation);
 	}
 
-	// Gather split params along 'base' when 'other' is colinear and overlapping
-	void collectSplitTsForColinearOverlap(const tmp::Edge &p_base, const tmp::Edge &p_other, std::vector<float> &p_ts)
+	std::array<const Face *, 6> _gatherNeighbourFaces(const NeightbourDescriber &p_neightbourDescriber) const
 	{
-		if (p_base.isColinear(p_other) == false)
+		std::array<const Face *, 6> neighFaces{};
+		for (size_t i = 0; i < 6; ++i)
 		{
-			return;
-		}
-
-		const float len2 = p_base.delta().dot(p_base.delta());
-		if (FLOAT_EQ(len2, 0.0f) == true)
-		{
-			return;
-		}
-
-		float t0 = p_base.project(p_other.first());
-		float t1 = p_base.project(p_other.second());
-		if (t1 < t0)
-		{
-			std::swap(t0, t1);
-		}
-
-		float lo = clampf(t0, 0.0f, len2);
-		float hi = clampf(t1, 0.0f, len2);
-
-		if (FLOAT_NEQ(hi - lo, 0.0f) == true)
-		{
-			p_ts.push_back(lo);
-			p_ts.push_back(hi);
-		}
-	}
-
-	void collectSplitTsForIntersection(const tmp::Edge &p_base, const tmp::Edge &p_other, const spk::Vector3 &p_normal, std::vector<float> &p_ts)
-	{
-		if (p_base.isColinear(p_other) == true)
-		{
-			return;
-		}
-
-		spk::Vector3 r = p_base.delta();
-		spk::Vector3 s = p_other.delta();
-		spk::Vector3 qp = p_other.first() - p_base.first();
-
-		float denom = r.cross(s).dot(p_normal);
-		if (FLOAT_EQ(denom, 0.0f) == true)
-		{
-			return;
-		}
-
-		float t = qp.cross(s).dot(p_normal) / denom;
-		float u = qp.cross(r).dot(p_normal) / denom;
-
-		const float eps = 1e-6f;
-		if (t > eps && t < 1.0f - eps && u >= -eps && u <= 1.0f + eps)
-		{
-			spk::Vector3 inter = p_base.first() + r * t;
-			p_ts.push_back(p_base.project(inter));
-		}
-	}
-
-	// Split one edge by collected ts
-	void splitEdgeByTs(const tmp::Edge &p_e, const std::vector<float> &p_ts, std::vector<tmp::Edge> &p_out)
-	{
-		const float len = p_e.delta().norm();
-		const float len2 = len * len;
-		if (FLOAT_EQ(len, 0.0f) == true)
-		{
-			return;
-		}
-
-		std::vector<float> cuts;
-		cuts.reserve(p_ts.size() + 2);
-		cuts.push_back(0.0f);
-		for (float t : p_ts)
-		{
-			if (t > 0.0f && t < len2)
-			{
-				cuts.push_back(t);
-			}
-		}
-		cuts.push_back(len2);
-		std::sort(cuts.begin(), cuts.end());
-		cuts.erase(std::unique(cuts.begin(), cuts.end(), [](float p_a, float p_b) { return FLOAT_EQ(p_a, p_b) == true; }), cuts.end());
-
-		for (size_t i = 1; i < cuts.size(); ++i)
-		{
-			float t0 = cuts[i - 1], t1 = cuts[i];
-			if (FLOAT_EQ(t1 - t0, 0.0f) == true)
+			neighFaces[i] = nullptr;
+			const auto &desc = p_neightbourDescriber[i];
+			if (desc.first == nullptr)
 			{
 				continue;
 			}
 
-			const spk::Vector3 a = p_e.first() + p_e.direction() * (t0 / len);
-			const spk::Vector3 b = p_e.first() + p_e.direction() * (t1 / len);
-			p_out.emplace_back(a, b);
+			const Block *neigh = desc.first;
+			const Orientation &neighOrientation = desc.second;
+
+			if (neigh->_cache.hasCase(neighOrientation) == false)
+			{
+				neigh->_cache.addCase(neighOrientation, neigh->_mesh());
+			}
+
+			const Cache::Entry &neighData = neigh->_cache.getCase(neighOrientation);
+			const spk::Vector3 oppositeNormal = -neightbourCoordinates[i];
+			if (auto it = neighData.faces.find(oppositeNormal); it != neighData.faces.end())
+			{
+				neighFaces[i] = &it->second;
+			}
+		}
+		return neighFaces;
+	}
+
+	static bool _allSixFull(const std::array<const Face *, 6> &p_neighFaces)
+	{
+		for (const Face *nf : p_neighFaces)
+		{
+			if (nf == nullptr || nf->full == false)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	static void _emitInnerIfNeeded(
+		spk::ObjMesh &p_toFill, const Cache::Entry &p_data, const spk::Vector3 &p_position, const std::array<const Face *, 6> &p_neighFaces)
+	{
+		if (_allSixFull(p_neighFaces) == false)
+		{
+			p_data.applyInnerMesh(p_toFill, p_position);
 		}
 	}
 
-	void splitAllEdges(std::vector<tmp::Edge> &p_base, const std::vector<tmp::Edge> &p_other, const spk::Vector3 &p_normal)
+	static spk::Polygon _translated(const spk::Polygon &p_poly, const spk::Vector3 &p_delta)
 	{
-		std::vector<tmp::Edge> result;
-		result.reserve(p_base.size() * 2);
-		for (const auto &e : p_base)
-		{
-			std::vector<float> ts;
-			for (const auto &o : p_other)
-			{
-				collectSplitTsForColinearOverlap(e, o, ts);
-				collectSplitTsForIntersection(e, o, p_normal, ts);
-			}
-			splitEdgeByTs(e, ts, result);
-		}
-		p_base.swap(result);
-	}
-
-	// Remove sub-edges that appear twice with opposite orientation.
-	// If edges overlap with the same orientation, keep a single copy.
-	std::vector<tmp::Edge> subtractInternalShared(const std::vector<tmp::Edge> &p_a, const std::vector<tmp::Edge> &p_b)
-	{
-		std::vector<bool> usedB(p_b.size(), false);
-		std::vector<tmp::Edge> out;
-		out.reserve(p_a.size() + p_b.size());
-
-		for (size_t i = 0; i < p_a.size(); ++i)
-		{
-			bool consumed = false;
-			for (size_t j = 0; j < p_b.size(); ++j)
-			{
-				if (usedB[j] == true)
-				{
-					continue;
-				}
-				if (p_a[i].isInverse(p_b[j]) == true)
-				{
-					usedB[j] = true;
-					consumed = true;
-					break;
-				}
-				if (p_a[i] == p_b[j])
-				{
-					usedB[j] = true;
-					out.push_back(p_a[i]);
-					consumed = true;
-					break;
-				}
-			}
-			if (consumed == false)
-			{
-				out.push_back(p_a[i]);
-			}
-		}
-		for (size_t j = 0; j < p_b.size(); ++j)
-		{
-			if (usedB[j] == false)
-			{
-				out.push_back(p_b[j]);
-			}
-		}
+		spk::Polygon out;
+		out.points().reserve(p_poly.points().size());
+		std::transform(
+			p_poly.points().begin(),
+			p_poly.points().end(),
+			std::back_inserter(out.points()),
+			[&](const spk::Vector3 &p_point) { return p_point + p_delta; });
 		return out;
 	}
 
-	std::vector<spk::Vector3> stitchLoop( // NOLINT(readability-function-cognitive-complexity)
-                const std::vector<tmp::Edge> &p_edges,
-                const spk::Vector3 &p_normal)
+	static void _emitVisibleFaces(
+		spk::ObjMesh &p_toFill, const Cache::Entry &p_data, const spk::Vector3 &p_position, const std::array<const Face *, 6> &p_neighFaces)
 	{
-		if (p_edges.empty() == true)
+		for (size_t i = 0; i < 6; ++i)
 		{
-			return {};
-		}
+			const spk::Vector3 normal = neightbourCoordinates[i];
 
-		spk::Vector3 up = p_normal.normalize();
-		spk::Vector3 yAxis = spk::Vector3(0, 1, 0);
-		if (up == yAxis || up == yAxis.inverse())
-		{
-			yAxis = spk::Vector3(0, 0, 1);
-		}
-		spk::Vector3 xAxis = yAxis.cross(up).normalize();
-		yAxis = up.cross(xAxis);
-
-		std::map<spk::Vector3, spk::Vector2> coords;
-		std::map<spk::Vector3, std::vector<std::pair<size_t, bool>>> adj;
-		for (size_t i = 0; i < p_edges.size(); ++i)
-		{
-			const tmp::Edge &e = p_edges[i];
-			auto insert = [&](const spk::Vector3 &p_v)
+			auto faceIt = p_data.faces.find(normal);
+			if (faceIt == p_data.faces.end())
 			{
-				if (coords.find(p_v) == coords.end())
-				{
-					coords[p_v] = spk::Vector2(p_v.dot(xAxis), p_v.dot(yAxis));
-				}
-			};
-			insert(e.first());
-			insert(e.second());
-			adj[e.first()].push_back({i, true});
-			adj[e.second()].push_back({i, false});
-		}
-
-		spk::Vector3 start = adj.begin()->first;
-		spk::Vector2 startCoord = coords[start];
-		for (const auto &kv : coords)
-		{
-			const spk::Vector2 &c = kv.second;
-			if (c.y < startCoord.y || (FLOAT_EQ(c.y, startCoord.y) == true && c.x < startCoord.x))
-			{
-				start = kv.first;
-				startCoord = c;
+				continue;
 			}
-		}
 
-		std::vector<bool> used(p_edges.size(), false);
-		std::vector<spk::Vector3> loop;
-		loop.push_back(start);
-		spk::Vector3 cur3 = start;
-		spk::Vector2 curDir(1.0f, 0.0f);
-
-		while (true)
-		{
-			float bestAng = -std::numeric_limits<float>::infinity();
-			size_t bestIdx = SIZE_MAX;
-			bool bestForward = true;
-			for (auto &opt : adj[cur3])
+			const Face &ourFace = faceIt->second;
+			if (ourFace.mesh.shapes().empty() == true)
 			{
-				size_t idx = opt.first;
-				bool forward = opt.second;
-				if (used[idx] == true)
+				continue;
+			}
+
+			const Face *neigh = p_neighFaces[i];
+			bool visible = true;
+
+			if (neigh != nullptr && neigh->mesh.shapes().empty() == false)
+			{
+				const spk::Vector3 toOurLocal = normal;
+				spk::Polygon neighInOurSpace = _translated(neigh->footprint, toOurLocal);
+
+				if (neighInOurSpace.contains(ourFace.footprint) == true)
 				{
-					continue;
-				}
-				spk::Vector3 next3 = forward == true ? p_edges[idx].second() : p_edges[idx].first();
-				spk::Vector2 dir = (coords[next3] - coords[cur3]).normalize();
-				float cross = curDir.x * dir.y - curDir.y * dir.x;
-				float dot = curDir.x * dir.x + curDir.y * dir.y;
-				float ang = std::atan2(cross, dot);
-				if (ang > bestAng)
-				{
-					bestAng = ang;
-					bestIdx = idx;
-					bestForward = forward;
+					visible = false;
 				}
 			}
-			if (bestIdx == SIZE_MAX)
+
+			if (visible == true)
 			{
-				break;
-			}
-			used[bestIdx] = true;
-			spk::Vector3 next3 = bestForward == true ? p_edges[bestIdx].second() : p_edges[bestIdx].first();
-			loop.push_back(next3);
-			curDir = (coords[next3] - coords[cur3]).normalize();
-			cur3 = next3;
-			if (cur3 == start)
-			{
-				break;
-			}
-		}
-
-		if (loop.size() >= 3 && ((loop.front() == loop.back()) == false))
-		{
-			loop.push_back(loop.front());
-		}
-		return loop;
-	}
-}
-
-tmp::Polygon tmp::Polygon::fuze(const Polygon &p_other) const
-{
-	if (isCoplanar(p_other) == false)
-	{
-		GENERATE_ERROR("Polygons must be coplanar");
-	}
-
-	if (isAdjacent(p_other) == false && isOverlapping(p_other) == false)
-	{
-		return tmp::Polygon();
-	}
-
-	spk::Vector3 n = normal();
-
-	std::vector<tmp::Edge> A = _edges;
-	std::vector<tmp::Edge> B = p_other.edges();
-
-	splitAllEdges(A, B, n);
-	splitAllEdges(B, A, n);
-
-	std::vector<tmp::Edge> boundary = subtractInternalShared(A, B);
-	if (boundary.empty())
-	{
-		GENERATE_ERROR("Fused polygon is empty or degenerate");
-	}
-
-	std::vector<spk::Vector3> loop = stitchLoop(boundary, n);
-	if (loop.size() < 4)
-	{
-		GENERATE_ERROR("Fused polygon could not be stitched");
-	}
-
-	return tmp::Polygon::fromLoop(loop);
-}
-
-class PolygonOutputer
-{
-private:
-	spk::Vector3 _min;
-	spk::Vector3 _max;
-
-	std::vector<tmp::Polygon> _polygons;
-
-	void _drawEdgeOnCanvas(
-		const tmp::Edge &p_edge, char p_polyChar, const spk::Vector3 &p_min, std::vector<std::string> &p_canvas, int p_width, int p_height) const
-	{
-		spk::Vector3 a = p_edge.first();
-		spk::Vector3 b = p_edge.second();
-
-		int x0 = static_cast<int>(std::round(a.x - p_min.x));
-		int y0 = static_cast<int>(std::round(a.y - p_min.y));
-		int x1 = static_cast<int>(std::round(b.x - p_min.x));
-		int y1 = static_cast<int>(std::round(b.y - p_min.y));
-
-		int dx = std::abs(x1 - x0);
-		int dy = -std::abs(y1 - y0);
-		int sx = (x0 < x1) ? 1 : -1;
-		int sy = (y0 < y1) ? 1 : -1;
-		int err = dx + dy;
-
-		while (true)
-		{
-			if (y0 >= 0 && y0 < p_height && x0 >= 0 && x0 < p_width)
-			{
-				p_canvas[p_height - 1 - y0][x0] = p_polyChar;
-			}
-			if (x0 == x1 && y0 == y1)
-			{
-				break;
-			}
-			int e2 = 2 * err;
-			if (e2 >= dy)
-			{
-				err += dy;
-				x0 += sx;
-			}
-			if (e2 <= dx)
-			{
-				err += dx;
-				y0 += sy;
+				p_data.applyFace(p_toFill, p_position, normal);
 			}
 		}
 	}
 
 public:
-	PolygonOutputer() :
-		_min(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max()),
-		_max(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest())
+	virtual ~Block() = default;
+
+	void bake(
+		spk::ObjMesh &p_toFill,
+		const NeightbourDescriber &p_neightbourDescriber,
+		const spk::Vector3 &p_position,
+		const Orientation &p_orientation) const
 	{
+		const Cache::Entry &data = _ensureCacheCase(p_orientation);
+
+		const auto neighFaces = _gatherNeighbourFaces(p_neightbourDescriber);
+
+		_emitInnerIfNeeded(p_toFill, data, p_position, neighFaces);
+
+		_emitVisibleFaces(p_toFill, data, p_position, neighFaces);
+	}
+};
+
+struct FullBlock : public Block
+{
+public:
+	struct Configuration
+	{
+		spk::SpriteSheet::Sprite front;
+		spk::SpriteSheet::Sprite back;
+		spk::SpriteSheet::Sprite left;
+		spk::SpriteSheet::Sprite right;
+		spk::SpriteSheet::Sprite top;
+		spk::SpriteSheet::Sprite bottom;
+	};
+
+private:
+	const spk::ObjMesh &_mesh() const override
+	{
+		return (_objMesh);
 	}
 
-	void addPolygon(const tmp::Polygon &p_polygon)
+	spk::ObjMesh _objMesh;
+	Configuration _configuration;
+
+public:
+	explicit FullBlock(const Configuration &p_configuration) :
+		_configuration(p_configuration)
 	{
-		_polygons.push_back(p_polygon);
-		for (const auto &edge : p_polygon.edges())
-		{
-			_min.x = std::min(_min.x, std::min(edge.first().x, edge.second().x));
-			_min.y = std::min(_min.y, std::min(edge.first().y, edge.second().y));
-			_min.z = std::min(_min.z, std::min(edge.first().z, edge.second().z));
-			_max.x = std::max(_max.x, std::max(edge.first().x, edge.second().x));
-			_max.y = std::max(_max.y, std::max(edge.first().y, edge.second().y));
-			_max.z = std::max(_max.z, std::max(edge.first().z, edge.second().z));
-		}
+		_objMesh = spk::ObjMesh::loadFromFile("playground/resources/obj/full_block.obj");
+
+		_applySprite(_objMesh.shapes()[0], _configuration.front);
+		_applySprite(_objMesh.shapes()[1], _configuration.back);
+		_applySprite(_objMesh.shapes()[2], _configuration.left);
+		_applySprite(_objMesh.shapes()[3], _configuration.right);
+		_applySprite(_objMesh.shapes()[4], _configuration.top);
+		_applySprite(_objMesh.shapes()[5], _configuration.bottom);
+	}
+};
+
+struct SlopeBlock : public Block
+{
+public:
+	struct Configuration
+	{
+		spk::SpriteSheet::Sprite triangleLeft;
+		spk::SpriteSheet::Sprite triangleRight;
+		spk::SpriteSheet::Sprite back;
+		spk::SpriteSheet::Sprite ramp;
+		spk::SpriteSheet::Sprite bottom;
+	};
+
+private:
+	const spk::ObjMesh &_mesh() const override
+	{
+		return (_objMesh);
 	}
 
-	void print() const
+	spk::ObjMesh _objMesh;
+	Configuration _configuration;
+
+public:
+	explicit SlopeBlock(const Configuration &p_configuration) :
+		_configuration(p_configuration)
 	{
-		if (_polygons.empty() == true || _max == (std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest()))
+		_objMesh = spk::ObjMesh::loadFromFile("playground/resources/obj/slope_block.obj");
+
+		_applySprite(_objMesh.shapes()[0], _configuration.bottom);
+		_applySprite(_objMesh.shapes()[1], _configuration.back);
+		_applySprite(_objMesh.shapes()[2], _configuration.triangleLeft);
+		_applySprite(_objMesh.shapes()[3], _configuration.triangleRight);
+		_applySprite(_objMesh.shapes()[4], _configuration.ramp);
+	}
+};
+
+struct HalfBlock : public Block
+{
+public:
+	struct Configuration
+	{
+		spk::SpriteSheet::Sprite front;
+		spk::SpriteSheet::Sprite back;
+		spk::SpriteSheet::Sprite left;
+		spk::SpriteSheet::Sprite right;
+		spk::SpriteSheet::Sprite top;
+		spk::SpriteSheet::Sprite bottom;
+	};
+
+private:
+	const spk::ObjMesh &_mesh() const override
+	{
+		return (_objMesh);
+	}
+
+	spk::ObjMesh _objMesh;
+	Configuration _configuration;
+
+public:
+	explicit HalfBlock(const Configuration &p_configuration) :
+		_configuration(p_configuration)
+	{
+		_objMesh = spk::ObjMesh::loadFromFile("playground/resources/obj/half_block.obj");
+
+		_applySprite(_objMesh.shapes()[0], _configuration.bottom);
+		_applySprite(_objMesh.shapes()[1], _configuration.top);
+		_applySprite(_objMesh.shapes()[2], _configuration.left);
+		_applySprite(_objMesh.shapes()[3], _configuration.left);
+		_applySprite(_objMesh.shapes()[4], _configuration.left);
+		_applySprite(_objMesh.shapes()[5], _configuration.left);
+	}
+};
+
+struct StairBlock : public Block
+{
+public:
+	struct Configuration
+	{
+		spk::SpriteSheet::Sprite bottom;
+		spk::SpriteSheet::Sprite staircaseTop;
+		spk::SpriteSheet::Sprite staircaseFront;
+		spk::SpriteSheet::Sprite left;
+		spk::SpriteSheet::Sprite right;
+		spk::SpriteSheet::Sprite back;
+	};
+
+private:
+	const spk::ObjMesh &_mesh() const override
+	{
+		return (_objMesh);
+	}
+
+	spk::ObjMesh _objMesh;
+	Configuration _configuration;
+
+public:
+	explicit StairBlock(const Configuration &p_configuration) :
+		_configuration(p_configuration)
+	{
+		_objMesh = spk::ObjMesh::loadFromFile("playground/resources/obj/stair_block.obj");
+
+		_applySprite(_objMesh.shapes()[0], _configuration.bottom);
+		_applySprite(_objMesh.shapes()[1], _configuration.staircaseTop);
+		_applySprite(_objMesh.shapes()[2], _configuration.staircaseTop);
+		_applySprite(_objMesh.shapes()[3], _configuration.staircaseFront);
+		_applySprite(_objMesh.shapes()[4], _configuration.staircaseFront);
+		_applySprite(_objMesh.shapes()[5], _configuration.back);
+		_applySprite(_objMesh.shapes()[6], _configuration.left);
+		_applySprite(_objMesh.shapes()[7], _configuration.left);
+		_applySprite(_objMesh.shapes()[8], _configuration.right);
+		_applySprite(_objMesh.shapes()[9], _configuration.right);
+	}
+};
+
+template <size_t ChunkSizeX, size_t ChunkSizeY, size_t ChunkSizeZ>
+class BlockMap : public spk::Entity
+{
+public:
+	class Chunk : public spk::Entity
+	{
+	public:
+		static inline const spk::Vector3Int size = spk::Vector3Int(ChunkSizeX, ChunkSizeY, ChunkSizeZ);
+
+	private:
+		class Data : public spk::Component
 		{
-			std::cout << "(no polygons)" << std::endl;
-			return;
-		}
+		private:
+			spk::SafePointer<spk::ObjMeshRenderer> _renderer;
+			spk::SafePointer<spk::CollisionMeshRenderer> _collisionRenderer;
+			spk::SafePointer<spk::RigidBody> _rigidBody;
 
-		int width = static_cast<int>(std::round(_max.x - _min.x)) + 1;
-		int height = static_cast<int>(std::round(_max.y - _min.y)) + 1;
+			spk::SafePointer<BlockMap> _blockMap;
+			std::array<std::array<std::array<Block::Specifier, ChunkSizeX>, ChunkSizeY>, ChunkSizeZ> _content;
 
-		std::vector<std::string> canvas(height, std::string(width, ' '));
+			bool _isBaked = false;
+			spk::ObjMesh _mesh;
+			spk::CollisionMesh _collisionMesh;
 
-		char polyChar = 'a';
-		for (size_t p = 0; p < _polygons.size(); ++p, ++polyChar)
-		{
-			for (const auto &edge : _polygons[p].edges())
+			Block::NeightbourDescriber _computeNeightbourSpecifiers(int p_x, int p_y, int p_z)
 			{
-				_drawEdgeOnCanvas(edge, polyChar, _min, canvas, width, height);
+				Block::NeightbourDescriber result;
+
+				for (size_t i = 0; i < Block::neightbourCoordinates.size(); i++)
+				{
+					spk::Vector3 tmpCoord = Block::neightbourCoordinates[i] + spk::Vector3{p_x, p_y, p_z};
+
+					Block::Specifier specifier = content(tmpCoord);
+
+					spk::SafePointer<const Block> block = nullptr;
+					if (specifier.first != -1)
+					{
+						block = _blockMap->blockById(specifier.first);
+					}
+
+					result[i] = std::make_pair(block, specifier.second);
+				}
+
+				return (result);
+			}
+
+			void _bake()
+			{
+				_mesh.clear();
+
+				for (int z = 0; z < size.z; ++z)
+				{
+					for (int y = 0; y < size.y; ++y)
+					{
+						for (int x = 0; x < size.x; ++x)
+						{
+							Block::Specifier &currentSpecifier = _content[x][y][z];
+
+							if (currentSpecifier.first != -1)
+							{
+								Block::NeightbourDescriber neightbourSpecifiers = _computeNeightbourSpecifiers(x, y, z);
+
+								spk::SafePointer<const Block> currentBlock = _blockMap->blockById(currentSpecifier.first);
+
+								currentBlock->bake(_mesh, neightbourSpecifiers, {x, y, z}, currentSpecifier.second);
+							}
+						}
+					}
+				}
+
+				_collisionMesh = spk::CollisionMesh::fromObjMesh(&_mesh);
+
+				_isBaked = true;
+			}
+
+		public:
+			Data(const std::wstring &p_name) :
+				spk::Component(p_name)
+			{
+			}
+
+			void setBlockMap(spk::SafePointer<BlockMap> p_blockMap)
+			{
+				_blockMap = p_blockMap;
+			}
+
+			void fill(Block::ID p_id)
+			{
+				for (int z = 0; z < size.z; ++z)
+				{
+					for (int y = 0; y < size.y; ++y)
+					{
+						for (int x = 0; x < size.x; ++x)
+						{
+							_content[x][y][z] = std::make_pair(
+								p_id, Block::Orientation{Block::HorizontalOrientation::XPositive, Block::VerticalOrientation::YPositive});
+						}
+					}
+				}
+				_isBaked = false;
+			}
+
+			void setContent(
+				int p_x,
+				int p_y,
+				int p_z,
+				const Block::ID &p_data,
+				const Block::Orientation &p_orientation = {Block::HorizontalOrientation::XPositive, Block::VerticalOrientation::YPositive})
+			{
+				_content[p_x][p_y][p_z] = std::make_pair(p_data, p_orientation);
+				_isBaked = false;
+			}
+
+			Block::Specifier content(const spk::Vector3Int &p_coord) const
+			{
+				return (content(p_coord.x, p_coord.y, p_coord.z));
+			}
+
+			Block::Specifier content(const spk::Vector2Int &p_coord, int p_z) const
+			{
+				return (content(p_coord.x, p_coord.y, p_z));
+			}
+
+			Block::Specifier content(int p_x, int p_y, int p_z) const
+			{
+				if (p_x < 0 || p_x >= size.x || p_y < 0 || p_y >= size.y || p_z < 0 || p_z >= size.z)
+				{
+					return std::make_pair(-1, Block::Orientation{});
+				}
+				return (_content[p_x][p_y][p_z]);
+			}
+
+			void start() override
+			{
+				_renderer = owner()->template getComponent<spk::ObjMeshRenderer>();
+				_collisionRenderer = owner()->template getComponent<spk::CollisionMeshRenderer>();
+				_rigidBody = owner()->template getComponent<spk::RigidBody>();
+			}
+
+			void onPaintEvent(spk::PaintEvent &p_event) override
+			{
+				if (_isBaked == false)
+				{
+					_bake();
+
+					if (_renderer != nullptr)
+					{
+						_renderer->setMesh(mesh());
+						_collisionRenderer->setMesh(collisionMesh());
+						_rigidBody->setCollider(collisionMesh());
+						p_event.requestPaint();
+					}
+				}
+			}
+
+			spk::SafePointer<spk::ObjMesh> mesh()
+			{
+				return (&_mesh);
+			}
+			const spk::SafePointer<const spk::ObjMesh> mesh() const
+			{
+				return (&_mesh);
+			}
+
+			spk::SafePointer<spk::CollisionMesh> collisionMesh()
+			{
+				return (&_collisionMesh);
+			}
+			const spk::SafePointer<const spk::CollisionMesh> collisionMesh() const
+			{
+				return (&_collisionMesh);
+			}
+		};
+
+		spk::SafePointer<spk::ObjMeshRenderer> _renderer;
+		spk::SafePointer<spk::CollisionMeshRenderer> _collisionRenderer;
+		spk::SafePointer<spk::RigidBody> _rigidBody;
+		spk::SafePointer<Data> _data;
+
+	public:
+		Chunk(const std::wstring &p_name, spk::SafePointer<BlockMap> p_parent) :
+			spk::Entity(p_name, p_parent)
+		{
+			_renderer = this->template addComponent<spk::ObjMeshRenderer>(p_name + L"/ObjMeshRenderer");
+			_collisionRenderer = this->template addComponent<spk::CollisionMeshRenderer>(p_name + L"/CollisionMeshRenderer");
+			_rigidBody = this->template addComponent<spk::RigidBody>(p_name + L"/RigidBody");
+			_data = this->template addComponent<Data>(p_name + L"/Data");
+			_data->setBlockMap(p_parent);
+
+			_renderer->setPriority(100);
+			_collisionRenderer->setPriority(100);
+			_collisionRenderer->setWireframe(true);
+			_collisionRenderer->deactivate();
+			_data->setPriority(0);
+		}
+
+		void setTexture(spk::SafePointer<const spk::Texture> p_texture)
+		{
+			_renderer->setTexture(p_texture);
+		}
+
+		void fill(Block::ID p_id)
+		{
+			_data->fill(p_id);
+		}
+
+		void setContent(
+			spk::Vector3Int p_position,
+			Block::ID p_id,
+			const Block::Orientation &p_orientation = {Block::HorizontalOrientation::XPositive, Block::VerticalOrientation::YPositive})
+		{
+			setContent(p_position.x, p_position.y, p_position.z, p_id, p_orientation);
+		}
+		void setContent(
+			spk::Vector2Int p_position,
+			int p_z,
+			Block::ID p_id,
+			const Block::Orientation &p_orientation = {Block::HorizontalOrientation::XPositive, Block::VerticalOrientation::YPositive})
+		{
+			setContent(p_position.x, p_position.y, p_z, p_id, p_orientation);
+		}
+
+		void setContent(
+			int p_x,
+			int p_y,
+			int p_z,
+			Block::ID p_id,
+			const Block::Orientation &p_orientation = {Block::HorizontalOrientation::XPositive, Block::VerticalOrientation::YPositive})
+		{
+			_data->setContent(p_x, p_y, p_z, p_id, p_orientation);
+		}
+
+		bool isBaked() const
+		{
+			return _data->isBaked();
+		}
+
+		spk::SafePointer<spk::ObjMesh> mesh()
+		{
+			return (_data->mesh());
+		}
+		const spk::SafePointer<const spk::ObjMesh> mesh() const
+		{
+			return (_data->mesh());
+		}
+
+		void useCollisionRenderer(bool p_use)
+		{
+			if (p_use == true)
+			{
+				_renderer->deactivate();
+				_collisionRenderer->activate();
+			}
+			else
+			{
+				_collisionRenderer->deactivate();
+				_renderer->activate();
+			}
+		}
+	};
+
+private:
+	spk::SafePointer<const spk::Texture> _texture;
+
+	std::unordered_map<Block::ID, std::unique_ptr<Block>> _availableBlocks;
+	std::unordered_map<spk::Vector3Int, std::unique_ptr<Chunk>> _chunks;
+
+	std::vector<spk::SafePointer<Chunk>> _activeChunks;
+
+	bool _useCollisionRenderer = false;
+
+	std::unique_ptr<Chunk> _generateChunk(const spk::Vector3Int &p_chunkCoordinate)
+	{
+		const std::wstring chunkName = name() + L"/Chunk[" + p_chunkCoordinate.to_wstring() + L"]";
+
+		std::unique_ptr<Chunk> newChunk = std::make_unique<Chunk>(chunkName, this);
+
+		newChunk->transform().place(p_chunkCoordinate * Chunk::size);
+		newChunk->setTexture(_texture);
+		newChunk->fill(-1);
+
+		_onChunkGeneration(p_chunkCoordinate, *newChunk);
+
+		newChunk->activate();
+
+		newChunk->useCollisionRenderer(_useCollisionRenderer);
+
+		return newChunk;
+	}
+
+	virtual void _onChunkGeneration(const spk::Vector3Int &p_chunkCoordinate, Chunk &p_chunkToFill)
+	{
+		for (size_t i = 0; i < Chunk::size.x; i++)
+		{
+			for (size_t j = 0; j < Chunk::size.z; j++)
+			{
+				p_chunkToFill.setContent(i, 0, j, 0);
+				if (i == 0 && j != 0)
+				{
+					p_chunkToFill.setContent(
+						i, 1, j, 2, Block::Orientation{Block::HorizontalOrientation::ZNegative, Block::VerticalOrientation::YPositive});
+				}
+				if (j == 0 && i != 0)
+				{
+					p_chunkToFill.setContent(
+						i, 1, j, 3, Block::Orientation{Block::HorizontalOrientation::ZPositive, Block::VerticalOrientation::YNegative});
+				}
+				if (i == 1 && j != 1)
+				{
+					p_chunkToFill.setContent(
+						i, 1, j, 1, Block::Orientation{Block::HorizontalOrientation::XPositive, Block::VerticalOrientation::YPositive});
+				}
+				if (j == 1 && i != 1)
+				{
+					p_chunkToFill.setContent(
+						i, 1, j, 1, Block::Orientation{Block::HorizontalOrientation::ZPositive, Block::VerticalOrientation::YPositive});
+				}
+				if (i == 0 && j == 0)
+				{
+					p_chunkToFill.setContent(i, 1, j, 0);
+					p_chunkToFill.setContent(i, 2, j, 0);
+					p_chunkToFill.setContent(i, 3, j, 0);
+					p_chunkToFill.setContent(i, 4, j, 0);
+				}
+			}
+		}
+	}
+
+public:
+	BlockMap(const std::wstring &p_name, spk::SafePointer<spk::Entity> p_parent) :
+		spk::Entity(p_name, p_parent)
+	{
+	}
+
+	void setTexture(spk::SafePointer<const spk::Texture> p_texture)
+	{
+		_texture = p_texture;
+
+		for (auto &[key, value] : _chunks)
+		{
+			value->setTexture(_texture);
+		}
+	}
+
+	void addBlockByID(const Block::ID &p_id, std::unique_ptr<Block> &&p_block)
+	{
+		if (_availableBlocks.contains(p_id) == true)
+		{
+			GENERATE_ERROR("Block ID [" + std::to_string(p_id) + "] already exist in BlockMap [" + spk::StringUtils::wstringToString(name()) + "]");
+		}
+		_availableBlocks[p_id] = std::move(p_block);
+	}
+
+	spk::SafePointer<const Block> blockById(Block::ID p_id) const
+	{
+		if (_availableBlocks.contains(p_id) == false)
+		{
+			return (nullptr);
+		}
+		return (_availableBlocks.at(p_id).get());
+	}
+
+	void setChunkRange(const spk::Vector3Int &p_start, const spk::Vector3Int &p_end)
+	{
+		for (auto &chunk : _activeChunks)
+		{
+			chunk->deactivate();
+		}
+		_activeChunks.clear();
+
+		for (int i = p_start.x; i <= p_end.x; i++)
+		{
+			for (int j = p_start.y; j <= p_end.y; j++)
+			{
+				for (int k = p_start.z; k <= p_end.z; k++)
+				{
+					spk::Vector3Int chunkPosition = {i, j, k};
+					if (_chunks.contains(chunkPosition) == false)
+					{
+						_chunks.emplace(chunkPosition, std::move(_generateChunk(chunkPosition)));
+					}
+
+					_activeChunks.push_back((_chunks[chunkPosition].get()));
+				}
 			}
 		}
 
-		for (const auto &row : canvas)
+		for (auto &chunk : _activeChunks)
 		{
-			std::cout << row << "\n";
+			chunk->activate();
+			chunk->useCollisionRenderer(_useCollisionRenderer);
+		}
+	}
+	void useCollisionRenderer(bool p_use)
+	{
+		_useCollisionRenderer = p_use;
+		for (auto &chunk : _activeChunks)
+		{
+			chunk->useCollisionRenderer(_useCollisionRenderer);
 		}
 	}
 };
 
-void checkPolygons(std::string_view p_nameA, const tmp::Polygon &p_polyA, std::string_view p_nameB, const tmp::Polygon &p_polyB)
+class Player : public spk::Entity
 {
-	std::cout << " ----- " << p_nameA << " -> " << p_nameB << " -----" << std::endl;
-	PolygonOutputer tmp;
-	tmp.addPolygon(p_polyA);
-	tmp.addPolygon(p_polyB);
-	tmp.print();
-	std::cout << " ----- ------ -----" << std::endl << std::endl;
+private:
+	spk::SafePointer<spk::CameraComponent> _cameraComponent = nullptr;
+	spk::SafePointer<spk::FreeViewController> _freeViewController = nullptr;
 
-	std::cout << "Is planar " << p_nameA << " : " << std::boolalpha << p_polyA.isPlanar() << std::endl;
-	std::cout << "Is planar " << p_nameB << " : " << std::boolalpha << p_polyB.isPlanar() << std::endl;
-	std::cout << "Is Coplanar : " << std::boolalpha << p_polyA.isCoplanar(p_polyB) << std::endl;
-	std::cout << "Is adjacent : " << std::boolalpha << p_polyA.isAdjacent(p_polyB) << std::endl;
-	std::cout << "Is overlapping : " << std::boolalpha << p_polyA.isOverlapping(p_polyB) << std::endl;
-
-	std::cout << " ----- Fused  -----" << std::endl << std::endl;
-	try
+public:
+	Player(const std::wstring &p_name, spk::SafePointer<spk::Entity> p_parent) :
+		spk::Entity(p_name, p_parent)
 	{
-		PolygonOutputer tmp;
-		tmp.addPolygon(p_polyA.fuze(p_polyB));
-		tmp.print();
-	} catch (const std::exception &e)
-	{
-		std::cout << e.what() << std::endl;
-	} catch (...)
-	{
-		std::cout << "Can't be fused : unknow error" << std::endl;
+		_cameraComponent = addComponent<spk::CameraComponent>(L"Player/CameraComponent");
+		_freeViewController = addComponent<spk::FreeViewController>(L"Player/FreeViewController");
 	}
-	std::cout << " ----- ------ -----" << std::endl << std::endl;
-}
+
+	spk::SafePointer<spk::CameraComponent> cameraComponent()
+	{
+		return (_cameraComponent);
+	}
+
+	spk::SafePointer<spk::FreeViewController> freeViewController()
+	{
+		return (_freeViewController);
+	}
+};
+
+template <size_t ChunkSizeX, size_t ChunkSizeY, size_t ChunkSizeZ>
+class CollisionRenderToggler : public spk::Component
+{
+private:
+	spk::SafePointer<BlockMap<ChunkSizeX, ChunkSizeY, ChunkSizeZ>> _blockMap;
+	bool _useCollisionRenderer = false;
+
+public:
+	CollisionRenderToggler(const std::wstring &p_name) :
+		spk::Component(p_name)
+	{
+	}
+
+	void setBlockMap(spk::SafePointer<BlockMap<ChunkSizeX, ChunkSizeY, ChunkSizeZ>> p_blockMap)
+	{
+		_blockMap = p_blockMap;
+	}
+
+	void onKeyboardEvent(spk::KeyboardEvent &p_event) override
+	{
+		if (p_event.type == spk::KeyboardEvent::Type::Press && p_event.key == spk::Keyboard::F1)
+		{
+			_useCollisionRenderer = (_useCollisionRenderer == false);
+			if (_blockMap != nullptr)
+			{
+				_blockMap->useCollisionRenderer(_useCollisionRenderer);
+			}
+		}
+	}
+};
+
+class RayCastPrinter : public spk::Component
+{
+private:
+	spk::SafePointer<spk::CameraComponent> _cameraComponent;
+	spk::Entity _cubeEntity;
+	spk::ColorMesh _cubeMesh;
+	bool _isCasting = false;
+
+	void _updateCubePosition(const spk::Vector2Int &p_mousePosition)
+	{
+		spk::Vector3 cameraDirection = _cameraComponent->camera().convertScreenToCamera(spk::Viewport::convertScreenToOpenGL(p_mousePosition));
+
+		const auto &camMtx = _cameraComponent->owner()->transform().model();
+		spk::Vector3 worldDirection = (camMtx * spk::Vector4(cameraDirection, 0.0f)).xyz().normalize();
+
+		auto hit = spk::RayCast::launch(owner(), worldDirection, 1000.0f);
+		if (hit.entity != nullptr)
+		{
+			_cubeEntity.transform().place(hit.position);
+		}
+	}
+
+public:
+	RayCastPrinter(const std::wstring &p_name) :
+		spk::Component(p_name)
+	{
+	}
+
+	spk::SafePointer<spk::Entity> cubeEntity()
+	{
+		return (&_cubeEntity);
+	}
+
+	void start() override
+	{
+		_cameraComponent = owner()->getComponent<spk::CameraComponent>();
+
+		owner()->engine()->addEntity(&_cubeEntity);
+
+		_cubeEntity.transform().place({3, 3, 3});
+		_cubeEntity.setName(L"RayCastCube");
+		_cubeEntity.activate();
+
+		auto renderer = _cubeEntity.addComponent<spk::ColorMeshRenderer>(L"RayCastCube/ColorMeshRenderer");
+		renderer->activate();
+
+		float s = 0.1f;
+		spk::Color color = spk::Color::red;
+
+		using CV = spk::ColorVertex;
+		CV v1{{-s, -s, -s}, color};
+		CV v2{{s, -s, -s}, color};
+		CV v3{{s, s, -s}, color};
+		CV v4{{-s, s, -s}, color};
+		CV v5{{-s, -s, s}, color};
+		CV v6{{s, -s, s}, color};
+		CV v7{{s, s, s}, color};
+		CV v8{{-s, s, s}, color};
+
+		_cubeMesh.clear();
+
+		_cubeMesh.addShape(v1, v4, v3, v2); // Back
+		_cubeMesh.addShape(v5, v6, v7, v8); // Front
+		_cubeMesh.addShape(v1, v5, v8, v4); // Left
+		_cubeMesh.addShape(v2, v3, v7, v6); // Right
+		_cubeMesh.addShape(v4, v8, v7, v3); // Top
+		_cubeMesh.addShape(v1, v2, v6, v5); // Bottom
+
+		renderer->setMesh(&_cubeMesh);
+	}
+
+	void onMouseEvent(spk::MouseEvent &p_event) override
+	{
+		if (_cameraComponent == nullptr)
+		{
+			return;
+		}
+
+		switch (p_event.type)
+		{
+		case spk::MouseEvent::Type::Press:
+			if (p_event.button == spk::Mouse::Button::Right)
+			{
+				_isCasting = true;
+				_updateCubePosition(p_event.mouse->position());
+			}
+			break;
+		case spk::MouseEvent::Type::Motion:
+			if (_isCasting == true)
+			{
+				_updateCubePosition(p_event.position);
+			}
+			break;
+		case spk::MouseEvent::Type::Release:
+			if (p_event.button == spk::Mouse::Button::Right)
+			{
+				_isCasting = false;
+			}
+			break;
+		default:
+			break;
+		}
+	}
+};
+
+class DebugOverlayManager : public spk::Widget
+{
+private:
+	spk::Profiler::Instanciator _profilerInstanciator;
+	spk::DebugOverlay<3, 20> _debugOverlay;
+
+	void _onGeometryChange() override
+	{
+		_debugOverlay.setGeometry({{0, 0}, geometry().size});
+	}
+
+	void _onUpdateEvent(spk::UpdateEvent &p_event) override
+	{
+		_debugOverlay.setText(0, 0, L"FPS : " + std::to_wstring(spk::Profiler::instance()->counter(L"FPS")->value()));
+		_debugOverlay.setText(0, 1, L"UPS : " + std::to_wstring(spk::Profiler::instance()->counter(L"UPS")->value()));
+		p_event.requestPaint();
+	}
+
+public:
+	DebugOverlayManager(const std::wstring &p_name, spk::SafePointer<spk::Widget> p_parent) :
+		spk::Widget(p_name, p_parent),
+		_debugOverlay(p_name + L"/Overlay", this)
+	{
+		_debugOverlay.activate();
+	}
+};
 
 int main()
 {
-	std::array<spk::Vector3, 4> points = {spk::Vector3{0, 0, 0}, spk::Vector3{10, 0, 0}, spk::Vector3{10, 10, 0}, spk::Vector3{0, 10, 0}};
-	spk::Vector3 deltaB = {10, 0, 0};
-	spk::Vector3 deltaC = {5, 10, 0};
-	spk::Vector3 deltaD = {5, 5, 0};
-	spk::Vector3 deltaE = {15, 5, 0};
-	tmp::Polygon polyA = tmp::Polygon::makeSquare(points[0], points[1], points[2], points[3]);
-	tmp::Polygon polyB = tmp::Polygon::makeSquare(points[0] + deltaB, points[1] + deltaB, points[2] + deltaB, points[3] + deltaB);
-	tmp::Polygon polyC = tmp::Polygon::makeSquare(points[0] + deltaC, points[1] + deltaC, points[2] + deltaC, points[3] + deltaC);
-	tmp::Polygon polyD = tmp::Polygon::makeSquare(points[0] + deltaD, points[1] + deltaD, points[2] + deltaD, points[3] + deltaD);
-	tmp::Polygon polyE = tmp::Polygon::makeSquare(points[0] + deltaE, points[1] + deltaE, points[2] + deltaE, points[3] + deltaE);
+	spk::GraphicalApplication app;
+	auto window = app.createWindow(L"Playground", {{0, 0}, {800, 600}});
+	window->setUpdateTimer(0);
+	window->requestMousePlacement({400, 300});
 
-	checkPolygons("A", polyA, "B", polyB);
-	checkPolygons("A", polyA, "C", polyC);
-	checkPolygons("A", polyA, "D", polyD);
-	checkPolygons("A", polyA, "E", polyE);
+	spk::GameEngine engine;
+	spk::GameEngineWidget engineWidget(L"EngineWidget", window->widget());
+	engineWidget.setGeometry({0, 0}, window->geometry().size);
+	engineWidget.setGameEngine(&engine);
+	engineWidget.setLayer(0);
+	engineWidget.activate();
 
-	return (0);
+	DebugOverlayManager debugOverlay(L"DebugOverlay", window->widget());
+	debugOverlay.setGeometry({0, 0}, window->geometry().size);
+	debugOverlay.setLayer(100);
+	debugOverlay.activate();
+
+	Player player = Player(L"Player", nullptr);
+	player.activate();
+	engine.addEntity(&player);
+
+	auto rayCastPrinter = player.addComponent<RayCastPrinter>(L"Player/RayCastPrinter");
+	rayCastPrinter->activate();
+
+	player.cameraComponent()->setPerspective(60.0f, static_cast<float>(window->geometry().size.x) / static_cast<float>(window->geometry().size.y));
+	player.transform().place({5.0f, 5.0f, 5.0f});
+	player.transform().lookAt({3.0f, 3.0f, 3.0f});
+
+	BlockMap<16, 16, 16> blockMap = BlockMap<16, 16, 16>(L"BlockMap", nullptr);
+	blockMap.setTexture(Block::texture());
+	blockMap.activate();
+	engine.addEntity(&blockMap);
+
+	auto fullBlockSprite = Block::spriteSheet().sprite({0, 0});
+	FullBlock::Configuration fullConfiguration;
+	fullConfiguration.front = fullBlockSprite;
+	fullConfiguration.back = fullBlockSprite;
+	fullConfiguration.left = fullBlockSprite;
+	fullConfiguration.right = fullBlockSprite;
+	fullConfiguration.top = fullBlockSprite;
+	fullConfiguration.bottom = fullBlockSprite;
+	blockMap.addBlockByID(0, std::make_unique<FullBlock>(fullConfiguration));
+
+	SlopeBlock::Configuration slopeConfiguration;
+	slopeConfiguration.triangleLeft = Block::spriteSheet().sprite({1, 0});
+	slopeConfiguration.triangleRight = Block::spriteSheet().sprite({1, 0});
+	slopeConfiguration.back = Block::spriteSheet().sprite({2, 0});
+	slopeConfiguration.ramp = Block::spriteSheet().sprite({2, 0});
+	slopeConfiguration.bottom = Block::spriteSheet().sprite({3, 0});
+	blockMap.addBlockByID(1, std::make_unique<SlopeBlock>(slopeConfiguration));
+
+	StairBlock::Configuration stairConfiguration;
+	stairConfiguration.staircaseTop = Block::spriteSheet().sprite({7, 0});
+	stairConfiguration.staircaseFront = Block::spriteSheet().sprite({7, 0});
+	stairConfiguration.left = Block::spriteSheet().sprite({6, 0});
+	stairConfiguration.right = Block::spriteSheet().sprite({6, 0});
+	stairConfiguration.back = Block::spriteSheet().sprite({8, 0});
+	stairConfiguration.bottom = Block::spriteSheet().sprite({8, 0});
+	blockMap.addBlockByID(2, std::make_unique<StairBlock>(stairConfiguration));
+
+	HalfBlock::Configuration halfConfiguration;
+	halfConfiguration.front = Block::spriteSheet().sprite({4, 0});
+	halfConfiguration.back = Block::spriteSheet().sprite({4, 0});
+	halfConfiguration.left = Block::spriteSheet().sprite({4, 0});
+	halfConfiguration.right = Block::spriteSheet().sprite({4, 0});
+	halfConfiguration.top = Block::spriteSheet().sprite({5, 0});
+	halfConfiguration.bottom = Block::spriteSheet().sprite({5, 0});
+	blockMap.addBlockByID(3, std::make_unique<HalfBlock>(halfConfiguration));
+
+	blockMap.setChunkRange({-0, 0, -0}, {0, 0, 0});
+
+	auto collisionRenderToggler = player.addComponent<CollisionRenderToggler<16, 16, 16>>(L"Player/CollisionRenderToggler");
+	collisionRenderToggler->setBlockMap(&blockMap);
+
+	return app.run();
 }

--- a/src/structure/engine/spk_collision_mesh.cpp
+++ b/src/structure/engine/spk_collision_mesh.cpp
@@ -14,22 +14,60 @@ namespace spk
 
 	CollisionMesh CollisionMesh::fromObjMesh(const spk::SafePointer<spk::ObjMesh> &p_mesh)
 	{
-		spk::CollisionMesh result;
-		for (const auto &shapeVariant : p_mesh->shapes())
+		try
 		{
-			spk::CollisionMesh::Unit unit;
-			if (std::holds_alternative<spk::ObjMesh::Quad>(shapeVariant) == true)
+			std::vector<spk::Polygon> polys;
+			for (const auto &shapeVariant : p_mesh->shapes())
 			{
-				const auto &q = std::get<spk::ObjMesh::Quad>(shapeVariant);
-				unit = spk::Polygon::makeSquare(q.a.position, q.b.position, q.c.position, q.d.position);
+				spk::Polygon poly;
+				if (std::holds_alternative<spk::ObjMesh::Quad>(shapeVariant) == true)
+				{
+					const auto &q = std::get<spk::ObjMesh::Quad>(shapeVariant);
+					poly = spk::Polygon::makeSquare(q.a.position, q.b.position, q.c.position, q.d.position);
+				}
+				else
+				{
+					const auto &t = std::get<spk::ObjMesh::Triangle>(shapeVariant);
+					poly = spk::Polygon::makeTri(t.a.position, t.b.position, t.c.position);
+				}
+				polys.push_back(poly);
 			}
-			else
+
+			bool merged = true;
+			while (merged == true)
 			{
-				const auto &t = std::get<spk::ObjMesh::Triangle>(shapeVariant);
-				unit = spk::Polygon::makeTri(t.a.position, t.b.position, t.c.position);
+				merged = false;
+				for (size_t i = 0; i < polys.size(); ++i)
+				{
+					for (size_t j = i + 1; j < polys.size();)
+					{
+						if (polys[i].isCoplanar(polys[j]) == true &&
+							(polys[i].isAdjacent(polys[j]) == true || polys[i].isOverlapping(polys[j]) == true))
+						{
+							polys[i] = polys[i].fuze(polys[j]);
+							polys.erase(polys.begin() + j);
+							merged = true;
+						}
+						else
+						{
+							++j;
+						}
+					}
+				}
 			}
-			result.addUnit(unit);
+
+			CollisionMesh result;
+			for (const auto &poly : polys)
+			{
+				result.addUnit(poly);
+			}
+			return result;
+		} catch (const std::exception &e)
+		{
+			GENERATE_ERROR(std::string("CollisionMesh::fromObjMesh - ") + e.what());
+		} catch (...)
+		{
+			GENERATE_ERROR("CollisionMesh::fromObjMesh - Unknown error");
 		}
-		return (result);
 	}
 }

--- a/src/structure/engine/spk_collision_mesh.cpp
+++ b/src/structure/engine/spk_collision_mesh.cpp
@@ -21,12 +21,12 @@ namespace spk
 			if (std::holds_alternative<spk::ObjMesh::Quad>(shapeVariant) == true)
 			{
 				const auto &q = std::get<spk::ObjMesh::Quad>(shapeVariant);
-				unit.points = {q.a.position, q.b.position, q.c.position, q.d.position};
+				unit = spk::Polygon::makeSquare(q.a.position, q.b.position, q.c.position, q.d.position);
 			}
 			else
 			{
 				const auto &t = std::get<spk::ObjMesh::Triangle>(shapeVariant);
-				unit.points = {t.a.position, t.b.position, t.c.position};
+				unit = spk::Polygon::makeTri(t.a.position, t.b.position, t.c.position);
 			}
 			result.addUnit(unit);
 		}

--- a/src/structure/engine/spk_collision_mesh_renderer.cpp
+++ b/src/structure/engine/spk_collision_mesh_renderer.cpp
@@ -92,20 +92,20 @@ void main()
 		unsigned int offset = 0;
 		for (const auto &unit : p_mesh.units())
 		{
-			for (const auto &point : unit.points)
+			for (const auto &point : unit.points())
 			{
 				_bufferSet.layout() << point;
 			}
-			if ((unit.points.size() == 3) == true)
+			if ((unit.points().size() == 3) == true)
 			{
 				_bufferSet.indexes() << (offset + 0) << (offset + 1) << (offset + 2);
 			}
-			else if ((unit.points.size() == 4) == true)
+			else if ((unit.points().size() == 4) == true)
 			{
 				_bufferSet.indexes() << (offset + 0) << (offset + 1) << (offset + 2);
 				_bufferSet.indexes() << (offset + 0) << (offset + 2) << (offset + 3);
 			}
-			offset += static_cast<unsigned int>(unit.points.size());
+			offset += static_cast<unsigned int>(unit.points().size());
 		}
 	}
 

--- a/src/structure/engine/spk_ray_cast.cpp
+++ b/src/structure/engine/spk_ray_cast.cpp
@@ -109,14 +109,15 @@ namespace
 		const spk::SafePointer<spk::Entity> &p_owner,
 		std::vector<spk::RayCast::Hit> &p_hits)
 	{
-		if ((p_unit.points.size() == 3) == true)
+		auto pts = p_unit.points();
+		if ((pts.size() == 3) == true)
 		{
-			Triangle tri{p_unit.points[0], p_unit.points[1], p_unit.points[2]};
+			Triangle tri{pts[0], pts[1], pts[2]};
 			processTriangle(p_eye, p_dir, p_maxDistance, p_offset, tri, p_owner, p_hits);
 		}
-		else if ((p_unit.points.size() == 4) == true)
+		else if ((pts.size() == 4) == true)
 		{
-			Quad quad{p_unit.points[0], p_unit.points[1], p_unit.points[2], p_unit.points[3]};
+			Quad quad{pts[0], pts[1], pts[2], pts[3]};
 			processQuad(p_eye, p_dir, p_maxDistance, p_offset, quad, p_owner, p_hits);
 		}
 	}

--- a/src/structure/engine/spk_rigid_body.cpp
+++ b/src/structure/engine/spk_rigid_body.cpp
@@ -51,7 +51,7 @@ namespace spk
 		{
 			for (const auto &unit : collider->units())
 			{
-				for (const auto &vertex : unit.points)
+				for (const auto &vertex : unit.points())
 				{
 					if (initialized == false)
 					{
@@ -100,7 +100,7 @@ namespace spk
 			{
 				for (const auto &unit : collider->units())
 				{
-					for (const auto &vertex : unit.points)
+					for (const auto &vertex : unit.points())
 					{
 						spk::Vector3 transformed = p_model * vertex;
 						if (initialized == false)
@@ -234,20 +234,21 @@ namespace spk
 			{
 				for (const auto &unit : collider->units())
 				{
-					if ((unit.points.size() == 3) == true)
+					auto pts = unit.points();
+					if ((pts.size() == 3) == true)
 					{
-						spk::TMesh<spk::Vector3>::Triangle tri{unit.points[0], unit.points[1], unit.points[2]};
+						spk::TMesh<spk::Vector3>::Triangle tri{pts[0], pts[1], pts[2]};
 						tri.a = p_transform * tri.a;
 						tri.b = p_transform * tri.b;
 						tri.c = p_transform * tri.c;
 						result.push_back(tri);
 					}
-					else if ((unit.points.size() == 4) == true)
+					else if ((pts.size() == 4) == true)
 					{
-						spk::Vector3 a = p_transform * unit.points[0];
-						spk::Vector3 b = p_transform * unit.points[1];
-						spk::Vector3 c = p_transform * unit.points[2];
-						spk::Vector3 d = p_transform * unit.points[3];
+						spk::Vector3 a = p_transform * pts[0];
+						spk::Vector3 b = p_transform * pts[1];
+						spk::Vector3 c = p_transform * pts[2];
+						spk::Vector3 d = p_transform * pts[3];
 						result.push_back({a, b, c});
 						result.push_back({a, c, d});
 					}

--- a/src/structure/math/spk_edge.cpp
+++ b/src/structure/math/spk_edge.cpp
@@ -1,52 +1,132 @@
 #include "structure/math/spk_edge.hpp"
+#include "spk_debug_macro.hpp"
 #include "structure/math/spk_constants.hpp"
-
-#include <utility>
 
 namespace spk
 {
 	Edge::Edge(const spk::Vector3 &p_first, const spk::Vector3 &p_second) :
-		first(p_first),
-		second(p_second)
+		_first(p_first),
+		_second(p_second)
 	{
+		if (_second == _first)
+		{
+			GENERATE_ERROR("Can't create an edge of lenght == 0");
+		}
+		_delta = (_second - _first);
+		_direction = _delta.normalize();
 	}
 
-	Edge Edge::inverse() const
+	const spk::Vector3 &Edge::first() const
 	{
-		return Edge(second, first);
+		return _first;
+	}
+
+	const spk::Vector3 &Edge::second() const
+	{
+		return _second;
+	}
+
+	const spk::Vector3 &Edge::delta() const
+	{
+		return _delta;
+	}
+
+	const spk::Vector3 &Edge::direction() const
+	{
+		return _direction;
+	}
+
+	float Edge::orientation(const spk::Vector3 &p_point, const spk::Vector3 &p_normal) const
+	{
+		return ((_second - _first).cross(p_point - _first)).dot(p_normal);
+	}
+
+	bool Edge::contains(const spk::Vector3 &p_point, bool p_checkAlignment) const
+	{
+		if (p_point == _first)
+		{
+			return true;
+		}
+		const spk::Vector3 v = p_point - _first;
+		if (p_checkAlignment == true && v.normalize() != _direction)
+		{
+			return false;
+		}
+		const float t = v.dot(_direction);
+		const float len = (_second - _first).dot(_direction);
+		return (t >= 0) && (t <= len);
+	}
+
+	float Edge::project(const spk::Vector3 &p_point) const
+	{
+		return _delta.dot(p_point - _first);
 	}
 
 	bool Edge::isInverse(const Edge &p_other) const
 	{
-		return (first == p_other.second) && (second == p_other.first);
+		return (_first == p_other.second() && _second == p_other.first());
+	}
+
+	Edge Edge::inverse() const
+	{
+		return Edge(_second, _first);
+	}
+
+	bool Edge::isParallel(const Edge &p_other) const
+	{
+		return (direction() == p_other.direction() || direction() == p_other.direction().inverse());
+	}
+
+	bool Edge::isColinear(const Edge &p_other) const
+	{
+		if (isParallel(p_other) == false)
+		{
+			return false;
+		}
+		spk::Vector3 delta = (p_other._first - _first);
+		if (delta == spk::Vector3(0, 0, 0))
+		{
+			return true;
+		}
+		return (std::fabs(delta.normalize().dot(_direction)) == 1);
 	}
 
 	bool Edge::colinear(const Edge &p_other) const
 	{
-		spk::Vector3 u = second - first;
-		spk::Vector3 v = p_other.second - p_other.first;
-		return u.cross(v).norm() <= spk::Constants::pointPrecision;
+		return isColinear(p_other);
 	}
 
 	bool Edge::operator==(const Edge &p_other) const
 	{
-		return (first == p_other.first) && (second == p_other.second);
+		return (first() == p_other.first()) && (second() == p_other.second());
 	}
 
 	bool Edge::operator<(const Edge &p_other) const
 	{
-		if (first != p_other.first)
+		if (first() != p_other.first())
 		{
-			return (first < p_other.first);
+			return (first() < p_other.first());
 		}
-		return (second < p_other.second);
+		return (second() < p_other.second());
+	}
+
+	std::ostream &operator<<(std::ostream &p_os, const Edge &p_edge)
+	{
+		p_os << "(" << p_edge.first() << " -> " << p_edge.second() << ")";
+		return p_os;
+	}
+
+	std::wostream &operator<<(std::wostream &p_wos, const Edge &p_edge)
+	{
+		p_wos << L"(" << p_edge.first() << L" -> " << p_edge.second() << L")";
+		return p_wos;
 	}
 }
 
 size_t std::hash<spk::Edge>::operator()(const spk::Edge &p_edge) const noexcept
 {
-	size_t h1 = std::hash<spk::Vector3>()(p_edge.first);
-	size_t h2 = std::hash<spk::Vector3>()(p_edge.second);
+	size_t h1 = std::hash<spk::Vector3>()(p_edge.first());
+	size_t h2 = std::hash<spk::Vector3>()(p_edge.second());
 	size_t seed = h1;
 	seed ^= h2 + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 	return seed;

--- a/src/structure/math/spk_polygon.cpp
+++ b/src/structure/math/spk_polygon.cpp
@@ -375,7 +375,18 @@ namespace spk
 			GENERATE_ERROR("Can't generate a normal for a polygon with less than 2 edges");
 		}
 
-		return (edgesRef[0].direction().cross(edgesRef[1].direction()));
+		spk::Vector3 n = edgesRef[0].direction().cross(edgesRef[1].direction());
+		for (size_t i = 2; (n == spk::Vector3(0, 0, 0)) == true && i < edgesRef.size(); ++i)
+		{
+			n = edgesRef[0].direction().cross(edgesRef[i].direction());
+		}
+
+		if ((n == spk::Vector3(0, 0, 0)) == true)
+		{
+			GENERATE_ERROR("Can't generate a normal for a polygon with colinear edges");
+		}
+
+		return n;
 	}
 
 	bool Polygon::isCoplanar(const Polygon &p_other) const

--- a/src/structure/math/spk_polygon.cpp
+++ b/src/structure/math/spk_polygon.cpp
@@ -9,6 +9,301 @@
 #include <map>
 #include <utility>
 
+namespace
+{
+	// Clamp a float in [min,max]
+	float clampf(float p_v, float p_lo, float p_hi)
+	{
+		return std::max(p_lo, std::min(p_v, p_hi));
+	}
+
+	// Gather split params along 'base' when 'other' is colinear and overlapping
+	void collectSplitTsForColinearOverlap(const spk::Edge &p_base, const spk::Edge &p_other, std::vector<float> &p_ts)
+	{
+		if (p_base.isColinear(p_other) == false)
+		{
+			return;
+		}
+
+		const float len2 = p_base.delta().dot(p_base.delta());
+		if (FLOAT_EQ(len2, 0.0f) == true)
+		{
+			return;
+		}
+
+		float t0 = p_base.project(p_other.first());
+		float t1 = p_base.project(p_other.second());
+		if (t1 < t0)
+		{
+			std::swap(t0, t1);
+		}
+
+		float lo = clampf(t0, 0.0f, len2);
+		float hi = clampf(t1, 0.0f, len2);
+
+		if (FLOAT_NEQ(hi - lo, 0.0f) == true)
+		{
+			p_ts.push_back(lo);
+			p_ts.push_back(hi);
+		}
+	}
+
+	void collectSplitTsForIntersection(const spk::Edge &p_base, const spk::Edge &p_other, const spk::Vector3 &p_normal, std::vector<float> &p_ts)
+	{
+		if (p_base.isColinear(p_other) == true)
+		{
+			return;
+		}
+
+		spk::Vector3 r = p_base.delta();
+		spk::Vector3 s = p_other.delta();
+		spk::Vector3 qp = p_other.first() - p_base.first();
+
+		float denom = r.cross(s).dot(p_normal);
+		if (FLOAT_EQ(denom, 0.0f) == true)
+		{
+			return;
+		}
+
+		float t = qp.cross(s).dot(p_normal) / denom;
+		float u = qp.cross(r).dot(p_normal) / denom;
+
+		const float eps = 1e-6f;
+		if (t > eps && t < 1.0f - eps && u >= -eps && u <= 1.0f + eps)
+		{
+			spk::Vector3 inter = p_base.first() + r * t;
+			p_ts.push_back(p_base.project(inter));
+		}
+	}
+
+	// Split one edge by collected ts
+	void splitEdgeByTs(const spk::Edge &p_e, const std::vector<float> &p_ts, std::vector<spk::Edge> &p_out)
+	{
+		const float len = p_e.delta().norm();
+		const float len2 = len * len;
+		if (FLOAT_EQ(len, 0.0f) == true)
+		{
+			return;
+		}
+
+		std::vector<float> cuts;
+		cuts.reserve(p_ts.size() + 2);
+		cuts.push_back(0.0f);
+		for (float t : p_ts)
+		{
+			if (t > 0.0f && t < len2)
+			{
+				cuts.push_back(t);
+			}
+		}
+		cuts.push_back(len2);
+		std::sort(cuts.begin(), cuts.end());
+		cuts.erase(std::unique(cuts.begin(), cuts.end(), [](float p_a, float p_b) { return FLOAT_EQ(p_a, p_b) == true; }), cuts.end());
+
+		for (size_t i = 1; i < cuts.size(); ++i)
+		{
+			float t0 = cuts[i - 1], t1 = cuts[i];
+			if (FLOAT_EQ(t1 - t0, 0.0f) == true)
+			{
+				continue;
+			}
+
+			const spk::Vector3 a = p_e.first() + p_e.direction() * (t0 / len);
+			const spk::Vector3 b = p_e.first() + p_e.direction() * (t1 / len);
+			p_out.emplace_back(a, b);
+		}
+	}
+
+	void splitAllEdges(std::vector<spk::Edge> &p_base, const std::vector<spk::Edge> &p_other, const spk::Vector3 &p_normal)
+	{
+		try
+		{
+			std::vector<spk::Edge> result;
+			result.reserve(p_base.size() * 2);
+			for (const auto &e : p_base)
+			{
+				std::vector<float> ts;
+				for (const auto &o : p_other)
+				{
+					collectSplitTsForColinearOverlap(e, o, ts);
+					collectSplitTsForIntersection(e, o, p_normal, ts);
+				}
+				splitEdgeByTs(e, ts, result);
+			}
+			p_base.swap(result);
+		} catch (const std::exception &e)
+		{
+			GENERATE_ERROR(std::string("splitAllEdges - ") + e.what());
+		} catch (...)
+		{
+			GENERATE_ERROR("splitAllEdges - Unknown error");
+		}
+	}
+
+	// Remove sub-edges that appear twice with opposite orientation.
+	// If edges overlap with the same orientation, keep a single copy.
+	std::vector<spk::Edge> subtractInternalShared(const std::vector<spk::Edge> &p_a, const std::vector<spk::Edge> &p_b)
+	{
+		try
+		{
+			std::vector<bool> usedB(p_b.size(), false);
+			std::vector<spk::Edge> out;
+			out.reserve(p_a.size() + p_b.size());
+
+			for (size_t i = 0; i < p_a.size(); ++i)
+			{
+				bool consumed = false;
+				for (size_t j = 0; j < p_b.size(); ++j)
+				{
+					if (usedB[j] == true)
+					{
+						continue;
+					}
+					if (p_a[i].isInverse(p_b[j]) == true)
+					{
+						usedB[j] = true;
+						consumed = true;
+						break;
+					}
+					if (p_a[i] == p_b[j])
+					{
+						usedB[j] = true;
+						out.push_back(p_a[i]);
+						consumed = true;
+						break;
+					}
+				}
+				if (consumed == false)
+				{
+					out.push_back(p_a[i]);
+				}
+			}
+			for (size_t j = 0; j < p_b.size(); ++j)
+			{
+				if (usedB[j] == false)
+				{
+					out.push_back(p_b[j]);
+				}
+			}
+			return out;
+		} catch (const std::exception &e)
+		{
+			GENERATE_ERROR(std::string("subtractInternalShared - ") + e.what());
+		} catch (...)
+		{
+			GENERATE_ERROR("subtractInternalShared - Unknown error");
+		}
+	}
+
+	std::vector<spk::Vector3> stitchLoop(const std::vector<spk::Edge> &p_edges, const spk::Vector3 &p_normal)
+	{
+		try
+		{
+			if (p_edges.empty() == true)
+			{
+				return {};
+			}
+
+			spk::Vector3 up = p_normal.normalize();
+			spk::Vector3 yAxis = spk::Vector3(0, 1, 0);
+			if (up == yAxis || up == yAxis.inverse())
+			{
+				yAxis = spk::Vector3(0, 0, 1);
+			}
+			spk::Vector3 xAxis = yAxis.cross(up).normalize();
+			yAxis = up.cross(xAxis);
+
+			std::map<spk::Vector3, spk::Vector2> coords;
+			std::map<spk::Vector3, std::vector<std::pair<size_t, bool>>> adj;
+			for (size_t i = 0; i < p_edges.size(); ++i)
+			{
+				const spk::Edge &e = p_edges[i];
+				auto insert = [&](const spk::Vector3 &p_v)
+				{
+					if (coords.find(p_v) == coords.end())
+					{
+						coords[p_v] = spk::Vector2(p_v.dot(xAxis), p_v.dot(yAxis));
+					}
+				};
+				insert(e.first());
+				insert(e.second());
+				adj[e.first()].push_back({i, true});
+				adj[e.second()].push_back({i, false});
+			}
+
+			spk::Vector3 start = adj.begin()->first;
+			spk::Vector2 startCoord = coords[start];
+			for (const auto &kv : coords)
+			{
+				const spk::Vector2 &c = kv.second;
+				if (c.y < startCoord.y || (FLOAT_EQ(c.y, startCoord.y) == true && c.x < startCoord.x))
+				{
+					start = kv.first;
+					startCoord = c;
+				}
+			}
+
+			std::vector<bool> used(p_edges.size(), false);
+			std::vector<spk::Vector3> loop;
+			loop.push_back(start);
+			spk::Vector3 cur3 = start;
+			spk::Vector2 curDir(1.0f, 0.0f);
+
+			while (true)
+			{
+				float bestAng = -std::numeric_limits<float>::infinity();
+				size_t bestIdx = SIZE_MAX;
+				bool bestForward = true;
+				for (auto &opt : adj[cur3])
+				{
+					size_t idx = opt.first;
+					bool forward = opt.second;
+					if (used[idx] == true)
+					{
+						continue;
+					}
+					spk::Vector3 next3 = forward == true ? p_edges[idx].second() : p_edges[idx].first();
+					spk::Vector2 dir = (coords[next3] - coords[cur3]).normalize();
+					float cross = curDir.x * dir.y - curDir.y * dir.x;
+					float dot = curDir.x * dir.x + curDir.y * dir.y;
+					float ang = std::atan2(cross, dot);
+					if (ang > bestAng)
+					{
+						bestAng = ang;
+						bestIdx = idx;
+						bestForward = forward;
+					}
+				}
+				if (bestIdx == SIZE_MAX)
+				{
+					break;
+				}
+				used[bestIdx] = true;
+				spk::Vector3 next3 = bestForward == true ? p_edges[bestIdx].second() : p_edges[bestIdx].first();
+				loop.push_back(next3);
+				curDir = (coords[next3] - coords[cur3]).normalize();
+				cur3 = next3;
+				if (cur3 == start)
+				{
+					break;
+				}
+			}
+
+			if (loop.size() >= 3 && ((loop.front() == loop.back()) == false))
+			{
+				loop.push_back(loop.front());
+			}
+			return loop;
+		} catch (const std::exception &e)
+		{
+			GENERATE_ERROR(std::string("stitchLoop - ") + e.what());
+		} catch (...)
+		{
+			GENERATE_ERROR("stitchLoop - Unknown error");
+		}
+	}
+}
+
 namespace spk
 {
 	void Polygon::_addEdge(const spk::Vector3 &p_a, const spk::Vector3 &p_b)
@@ -139,10 +434,18 @@ namespace spk
 			return false;
 		}
 
-		spk::Vector3 currentNormal = normal();
-		spk::Vector3 otherNormal = p_other.normal();
+		spk::Vector3 n1 = normal().normalize();
+		spk::Vector3 n2 = p_other.normal().normalize();
 
-		return ((currentNormal == otherNormal || currentNormal.inverse() == otherNormal) && currentNormal.dot(p_other.edges()[0].first()) == 0);
+		if (((n1 == n2) == false) && ((n1 == n2.inverse()) == false))
+		{
+			return false;
+		}
+
+		float d1 = n1.dot(edges()[0].first());
+		float d2 = n1.dot(p_other.edges()[0].first());
+
+		return (FLOAT_EQ(d1, d2) == true);
 	}
 
 	bool Polygon::isAdjacent(const Polygon &p_other) const
@@ -298,52 +601,84 @@ namespace spk
 
 	Polygon Polygon::fuze(const Polygon &p_other) const
 	{
-		if (isCoplanar(p_other) == false)
+		try
 		{
-			GENERATE_ERROR("Polygons must be coplanar");
-		}
+			if (isCoplanar(p_other) == false)
+			{
+				GENERATE_ERROR("Polygons must be coplanar");
+			}
 
-		if (isAdjacent(p_other) == false && isOverlapping(p_other) == false)
+			if (isAdjacent(p_other) == false && isOverlapping(p_other) == false)
+			{
+				return Polygon();
+			}
+
+			spk::Vector3 n = normal();
+
+			std::vector<spk::Edge> A = edges();
+			std::vector<spk::Edge> B = p_other.edges();
+
+			splitAllEdges(A, B, n);
+			splitAllEdges(B, A, n);
+
+			std::vector<spk::Edge> boundary = subtractInternalShared(A, B);
+			if (boundary.empty())
+			{
+				GENERATE_ERROR("Fused polygon is empty or degenerate");
+			}
+
+			std::vector<spk::Vector3> loop = stitchLoop(boundary, n);
+			if (loop.size() < 4)
+			{
+				GENERATE_ERROR("Fused polygon could not be stitched");
+			}
+
+			return Polygon::fromLoop(loop);
+		} catch (const std::exception &e)
 		{
-			return Polygon();
-		}
-
-		spk::Vector3 n = normal();
-
-		std::vector<spk::Edge> A = edges();
-		std::vector<spk::Edge> B = p_other.edges();
-
-		splitAllEdges(A, B, n);
-		splitAllEdges(B, A, n);
-
-		std::vector<spk::Edge> boundary = subtractInternalShared(A, B);
-		if (boundary.empty())
+			GENERATE_ERROR(std::string("Polygon::fuze - ") + e.what());
+		} catch (...)
 		{
-			GENERATE_ERROR("Fused polygon is empty or degenerate");
+			GENERATE_ERROR("Polygon::fuze - Unknown error");
 		}
-
-		std::vector<spk::Vector3> loop = stitchLoop(boundary, n);
-		if (loop.size() < 4)
-		{
-			GENERATE_ERROR("Fused polygon could not be stitched");
-		}
-
-		return Polygon::fromLoop(loop);
 	}
 
 	Polygon Polygon::fromLoop(const std::vector<spk::Vector3> &p_vs)
 	{
-		Polygon r;
-		if (p_vs.size() < 2)
+		try
 		{
+			Polygon r;
+			if (p_vs.size() < 2)
+			{
+				return r;
+			}
+
+			for (size_t i = 1; i < p_vs.size(); ++i)
+			{
+				const spk::Vector3 &a = p_vs[i - 1];
+				const spk::Vector3 &b = p_vs[i];
+				if (a == b)
+				{
+					continue;
+				}
+				r._addEdge(a, b);
+			}
+
+			const spk::Vector3 &first = p_vs.front();
+			const spk::Vector3 &last = p_vs.back();
+			if (first != last)
+			{
+				r._addEdge(last, first);
+			}
+
 			return r;
-		}
-		for (size_t i = 1; i < p_vs.size(); ++i)
+		} catch (const std::exception &e)
 		{
-			r._addEdge(p_vs[i - 1], p_vs[i]);
+			GENERATE_ERROR(std::string("Polygon::fromLoop - ") + e.what());
+		} catch (...)
+		{
+			GENERATE_ERROR("Polygon::fromLoop - Unknown error");
 		}
-		r._addEdge(p_vs.back(), p_vs.front());
-		return r;
 	}
 
 	Polygon Polygon::makeTri(const spk::Vector3 &p_a, const spk::Vector3 &p_b, const spk::Vector3 &p_c)
@@ -399,277 +734,5 @@ namespace spk
 		}
 		p_wos << L"}";
 		return p_wos;
-	}
-}
-
-namespace
-{
-	float clampf(float p_v, float p_lo, float p_hi)
-	{
-		return std::max(p_lo, std::min(p_v, p_hi));
-	}
-
-	void collectSplitTsForColinearOverlap(const spk::Edge &p_base, const spk::Edge &p_other, std::vector<float> &p_ts)
-	{
-		if (p_base.isColinear(p_other) == false)
-		{
-			return;
-		}
-
-		const float len2 = p_base.delta().dot(p_base.delta());
-		if (FLOAT_EQ(len2, 0.0f) == true)
-		{
-			return;
-		}
-
-		float t0 = p_base.project(p_other.first());
-		float t1 = p_base.project(p_other.second());
-		if (t1 < t0)
-		{
-			std::swap(t0, t1);
-		}
-
-		float lo = clampf(t0, 0.0f, len2);
-		float hi = clampf(t1, 0.0f, len2);
-
-		if (FLOAT_NEQ(hi - lo, 0.0f) == true)
-		{
-			p_ts.push_back(lo);
-			p_ts.push_back(hi);
-		}
-	}
-
-	void collectSplitTsForIntersection(const spk::Edge &p_base, const spk::Edge &p_other, const spk::Vector3 &p_normal, std::vector<float> &p_ts)
-	{
-		if (p_base.isColinear(p_other) == true)
-		{
-			return;
-		}
-
-		spk::Vector3 r = p_base.delta();
-		spk::Vector3 s = p_other.delta();
-		spk::Vector3 qp = p_other.first() - p_base.first();
-
-		float denom = r.cross(s).dot(p_normal);
-		if (FLOAT_EQ(denom, 0.0f) == true)
-		{
-			return;
-		}
-
-		float t = qp.cross(s).dot(p_normal) / denom;
-		float u = qp.cross(r).dot(p_normal) / denom;
-
-		const float eps = 1e-6f;
-		if (t > eps && t < 1.0f - eps && u >= -eps && u <= 1.0f + eps)
-		{
-			spk::Vector3 inter = p_base.first() + r * t;
-			p_ts.push_back(p_base.project(inter));
-		}
-	}
-
-	void splitEdgeByTs(const spk::Edge &p_e, const std::vector<float> &p_ts, std::vector<spk::Edge> &p_out)
-	{
-		const float len = p_e.delta().norm();
-		const float len2 = len * len;
-		if (FLOAT_EQ(len, 0.0f) == true)
-		{
-			return;
-		}
-		if (p_ts.empty())
-		{
-			p_out.push_back(p_e);
-			return;
-		}
-
-		std::vector<float> cuts = p_ts;
-		cuts.push_back(0.0f);
-		cuts.push_back(len2);
-		std::sort(cuts.begin(), cuts.end());
-		cuts.erase(std::unique(cuts.begin(), cuts.end(), [](float p_a, float p_b) { return FLOAT_EQ(p_a, p_b) == true; }), cuts.end());
-
-		for (size_t i = 1; i < cuts.size(); ++i)
-		{
-			float t0 = cuts[i - 1];
-			float t1 = cuts[i];
-			if (FLOAT_EQ(t1 - t0, 0.0f) == true)
-			{
-				continue;
-			}
-
-			float alpha0 = std::max(0.0f, std::min(1.0f, t0 / len2));
-			float alpha1 = std::max(0.0f, std::min(1.0f, t1 / len2));
-
-			spk::Vector3 A = p_e.first() + p_e.delta() * alpha0;
-			spk::Vector3 B = p_e.first() + p_e.delta() * alpha1;
-			if (FLOAT_EQ((B - A).norm(), 0.0f) == true)
-			{
-				continue;
-			}
-
-			p_out.emplace_back(A, B);
-		}
-	}
-
-	void splitAllEdges(std::vector<spk::Edge> &p_base, const std::vector<spk::Edge> &p_other, const spk::Vector3 &p_normal)
-	{
-		std::vector<spk::Edge> result;
-		for (const auto &e : p_base)
-		{
-			std::vector<float> ts;
-			for (const auto &o : p_other)
-			{
-				collectSplitTsForColinearOverlap(e, o, ts);
-				collectSplitTsForIntersection(e, o, p_normal, ts);
-			}
-
-			splitEdgeByTs(e, ts, result);
-		}
-		p_base = result;
-	}
-
-	std::vector<spk::Edge> subtractInternalShared(const std::vector<spk::Edge> &p_a, const std::vector<spk::Edge> &p_b)
-	{
-		std::vector<spk::Edge> out;
-		for (const auto &ea : p_a)
-		{
-			bool inside = false;
-			for (const auto &eb : p_b)
-			{
-				if (ea.isColinear(eb) == true && eb.contains(ea.first()) == true && eb.contains(ea.second()) == true)
-				{
-					inside = true;
-					break;
-				}
-			}
-			if (inside == false)
-			{
-				out.push_back(ea);
-			}
-		}
-		return out;
-	}
-
-	std::vector<spk::Vector3> stitchLoop(const std::vector<spk::Edge> &p_edges, const spk::Vector3 &p_normal)
-	{
-		if (p_edges.empty())
-		{
-			return {};
-		}
-
-		std::map<spk::Vector3, spk::Vector2> coords;
-		spk::Vector3 u = p_edges[0].delta().normalize();
-		spk::Vector3 v = p_normal.cross(u);
-		for (const auto &e : p_edges)
-		{
-			if (coords.find(e.first()) == coords.end())
-			{
-				coords[e.first()] = spk::Vector2(e.first().dot(u), e.first().dot(v));
-			}
-			if (coords.find(e.second()) == coords.end())
-			{
-				coords[e.second()] = spk::Vector2(e.second().dot(u), e.second().dot(v));
-			}
-		}
-
-		spk::Vector3 start = p_edges[0].first();
-		spk::Vector2 startCoord = coords[start];
-		for (const auto &e : p_edges)
-		{
-			spk::Vector2 c = coords[e.first()];
-			if (c.y < startCoord.y || (FLOAT_EQ(c.y, startCoord.y) == true && c.x < startCoord.x))
-			{
-				start = e.first();
-				startCoord = c;
-			}
-			c = coords[e.second()];
-			if (c.y < startCoord.y || (FLOAT_EQ(c.y, startCoord.y) == true && c.x < startCoord.x))
-			{
-				start = e.second();
-				startCoord = c;
-			}
-		}
-
-		std::vector<std::pair<size_t, bool>> unused;
-		unused.reserve(p_edges.size());
-		for (size_t i = 0; i < p_edges.size(); ++i)
-		{
-			unused.emplace_back(i, true);
-			unused.emplace_back(i, false);
-		}
-
-		std::vector<std::vector<std::pair<size_t, bool>>> adj(coords.size());
-		std::map<spk::Vector3, size_t> index;
-		{
-			std::vector<spk::Vector3> verts;
-			verts.reserve(coords.size());
-			for (auto &kv : coords)
-			{
-				index[kv.first] = verts.size();
-				verts.push_back(kv.first);
-			}
-			for (size_t i = 0; i < p_edges.size(); ++i)
-			{
-				spk::Vector3 a = p_edges[i].first();
-				spk::Vector3 b = p_edges[i].second();
-				size_t ia = index[a];
-				size_t ib = index[b];
-				adj[ia].emplace_back(i, true);
-				adj[ib].emplace_back(i, false);
-			}
-		}
-
-		std::vector<spk::Vector3> loop;
-		spk::Vector3 cur3 = start;
-		spk::Vector2 curCoord = coords[cur3];
-		spk::Vector2 curDir(1.0f, 0.0f);
-
-		std::vector<bool> used(p_edges.size(), false);
-
-		loop.push_back(cur3);
-		while (true)
-		{
-			float bestAng = -std::numeric_limits<float>::infinity();
-			size_t bestIdx = SIZE_MAX;
-			bool bestForward = true;
-			for (auto &opt : adj[index[cur3]])
-			{
-				size_t idx = opt.first;
-				bool forward = opt.second;
-				if (used[idx] == true)
-				{
-					continue;
-				}
-				spk::Vector3 next3 = forward == true ? p_edges[idx].second() : p_edges[idx].first();
-				spk::Vector2 dir = (coords[next3] - coords[cur3]).normalize();
-				float cross = curDir.x * dir.y - curDir.y * dir.x;
-				float dot = curDir.x * dir.x + curDir.y * dir.y;
-				float ang = std::atan2(cross, dot);
-				if (ang > bestAng)
-				{
-					bestAng = ang;
-					bestIdx = idx;
-					bestForward = forward;
-				}
-			}
-			if (bestIdx == SIZE_MAX)
-			{
-				break;
-			}
-			used[bestIdx] = true;
-			spk::Vector3 next3 = bestForward == true ? p_edges[bestIdx].second() : p_edges[bestIdx].first();
-			loop.push_back(next3);
-			curDir = (coords[next3] - coords[cur3]).normalize();
-			cur3 = next3;
-			if (cur3 == start)
-			{
-				break;
-			}
-		}
-
-		if (loop.size() >= 3 && ((loop.front() == loop.back()) == false))
-		{
-			loop.push_back(loop.front());
-		}
-		return loop;
 	}
 }

--- a/src/structure/math/spk_polygon.cpp
+++ b/src/structure/math/spk_polygon.cpp
@@ -589,15 +589,15 @@ namespace spk
 			splitAllEdges(B, A, n);
 
 			std::vector<spk::Edge> boundary = subtractInternalShared(A, B);
-			if (boundary.empty())
+			if (boundary.empty() == true)
 			{
-				GENERATE_ERROR("Fused polygon is empty or degenerate");
+				return Polygon();
 			}
 
 			std::vector<spk::Vector3> loop = stitchLoop(boundary, n);
 			if (loop.size() < 4)
 			{
-				GENERATE_ERROR("Fused polygon could not be stitched");
+				return Polygon();
 			}
 
 			return Polygon::fromLoop(loop);

--- a/src/structure/math/spk_polygon.cpp
+++ b/src/structure/math/spk_polygon.cpp
@@ -1,0 +1,648 @@
+#include "structure/math/spk_polygon.hpp"
+#include "spk_debug_macro.hpp"
+#include "structure/math/spk_constants.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <utility>
+
+namespace spk
+{
+	void Polygon::_addEdge(const spk::Vector3 &p_a, const spk::Vector3 &p_b)
+	{
+		_edges.push_back(spk::Edge(p_a, p_b));
+	}
+
+	bool Polygon::_edgesIntersect(const spk::Edge &p_a, const spk::Edge &p_b, const spk::Vector3 &p_normal, float p_eps)
+	{
+		float o1 = p_a.orientation(p_b.first(), p_normal);
+		float o2 = p_a.orientation(p_b.second(), p_normal);
+		float o3 = p_b.orientation(p_a.first(), p_normal);
+		float o4 = p_b.orientation(p_a.second(), p_normal);
+
+		bool cond1 = ((o1 > p_eps && o2 < -p_eps) || (o1 < -p_eps && o2 > p_eps));
+		bool cond2 = ((o3 > p_eps && o4 < -p_eps) || (o3 < -p_eps && o4 > p_eps));
+
+		return (cond1 == true && cond2 == true);
+	}
+
+	bool Polygon::_isPointInside(const Polygon &p_poly, const spk::Vector3 &p_point, float p_eps)
+	{
+		const auto &edges = p_poly.edges();
+		spk::Vector3 n = p_poly.normal();
+		float orient = edges[0].direction().cross(edges[1].direction()).dot(n);
+
+		for (size_t i = 0; i < edges.size(); i++)
+		{
+			const spk::Edge &edge = edges[i];
+			float val = edge.direction().cross(p_point - edge.first()).dot(n);
+
+			if (orient > 0)
+			{
+				if (val <= p_eps)
+				{
+					return false;
+				}
+			}
+			else
+			{
+				if (val >= -p_eps)
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	const std::vector<spk::Edge> &Polygon::edges() const
+	{
+		return _edges;
+	}
+
+	std::vector<spk::Vector3> Polygon::points() const
+	{
+		std::vector<spk::Vector3> pts;
+		pts.reserve(_edges.size());
+		for (const auto &e : _edges)
+		{
+			pts.push_back(e.first());
+		}
+		return pts;
+	}
+
+	bool Polygon::isPlanar() const
+	{
+		if (_edges.size() < 2)
+		{
+			return false;
+		}
+
+		spk::Vector3 expectedNormal = normal();
+
+		for (size_t i = 2; i < _edges.size(); i++)
+		{
+			float dot = expectedNormal.dot(_edges[i].direction());
+
+			if (dot != 0)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	spk::Vector3 Polygon::normal() const
+	{
+		if (_edges.size() < 2)
+		{
+			GENERATE_ERROR("Can't generate a normal for a polygon with less than 2 edges");
+		}
+
+		return (_edges[0].direction().cross(_edges[1].direction()));
+	}
+
+	bool Polygon::isCoplanar(const Polygon &p_other) const
+	{
+		if (isPlanar() == false)
+		{
+			return false;
+		}
+
+		if (p_other.isPlanar() == false)
+		{
+			return false;
+		}
+
+		spk::Vector3 currentNormal = normal();
+		spk::Vector3 otherNormal = p_other.normal();
+
+		return ((currentNormal == otherNormal || currentNormal.inverse() == otherNormal) && currentNormal.dot(p_other.edges()[0].first()) == 0);
+	}
+
+	bool Polygon::isAdjacent(const Polygon &p_other) const
+	{
+		if (isCoplanar(p_other) == false)
+		{
+			return false;
+		}
+
+		for (const auto &edgeA : _edges)
+		{
+			for (const auto &edgeB : p_other.edges())
+			{
+				if (edgeA.isColinear(edgeB) == true)
+				{
+					if (edgeA.contains(edgeB.first(), false) || edgeA.contains(edgeB.second(), false) || edgeB.contains(edgeA.first(), false) ||
+						edgeB.contains(edgeA.second(), false))
+					{
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	bool Polygon::isConvex(float p_eps, bool p_strictly) const
+	{
+		if (_edges.size() < 3)
+		{
+			return false;
+		}
+
+		spk::Vector3 polyNormal = normal();
+		float orientation = 0;
+
+		for (size_t i = 0; i < _edges.size(); i++)
+		{
+			const spk::Edge &current = _edges[i];
+			const spk::Edge &next = _edges[(i + 1) % _edges.size()];
+
+			float dot = current.direction().cross(next.direction()).dot(polyNormal);
+
+			if (std::fabs(dot) <= p_eps)
+			{
+				if (p_strictly == true)
+				{
+					return false;
+				}
+				continue;
+			}
+
+			if (orientation == 0)
+			{
+				orientation = (dot > 0) ? 1.0f : -1.0f;
+			}
+			else if (((dot > 0) ? 1.0f : -1.0f) != orientation)
+			{
+				return false;
+			}
+		}
+
+		return (orientation != 0);
+	}
+
+	bool Polygon::isOverlapping(const Polygon &p_other) const
+	{
+		if (isCoplanar(p_other) == false)
+		{
+			return false;
+		}
+
+		const float eps = 1e-6f;
+		spk::Vector3 polyNormal = normal();
+
+		for (const auto &edgeA : _edges)
+		{
+			for (const auto &edgeB : p_other.edges())
+			{
+				if (_edgesIntersect(edgeA, edgeB, polyNormal, eps) == true)
+				{
+					return true;
+				}
+			}
+		}
+
+		if (_isPointInside(*this, p_other.edges()[0].first(), eps) == true)
+		{
+			return true;
+		}
+
+		if (_isPointInside(p_other, _edges[0].first(), eps) == true)
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	bool Polygon::contains(const spk::Vector3 &p_point) const
+	{
+		const float eps = 1e-6f;
+		spk::Vector3 n = normal();
+		float orient = _edges[0].direction().cross(_edges[1].direction()).dot(n);
+
+		for (const auto &edge : _edges)
+		{
+			float val = edge.direction().cross(p_point - edge.first()).dot(n);
+
+			if (std::fabs(val) <= eps && edge.contains(p_point, false) == true)
+			{
+				return true;
+			}
+
+			if (orient > 0)
+			{
+				if (val < -eps)
+				{
+					return false;
+				}
+			}
+			else
+			{
+				if (val > eps)
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	bool Polygon::contains(const Polygon &p_polygon) const
+	{
+		if (isCoplanar(p_polygon) == false)
+		{
+			return false;
+		}
+		for (const auto &pt : p_polygon.points())
+		{
+			if (contains(pt) == false)
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	Polygon Polygon::fuze(const Polygon &p_other) const
+	{
+		if (isCoplanar(p_other) == false)
+		{
+			GENERATE_ERROR("Polygons must be coplanar");
+		}
+
+		if (isAdjacent(p_other) == false && isOverlapping(p_other) == false)
+		{
+			return Polygon();
+		}
+
+		spk::Vector3 n = normal();
+
+		std::vector<spk::Edge> A = _edges;
+		std::vector<spk::Edge> B = p_other.edges();
+
+		splitAllEdges(A, B, n);
+		splitAllEdges(B, A, n);
+
+		std::vector<spk::Edge> boundary = subtractInternalShared(A, B);
+		if (boundary.empty())
+		{
+			GENERATE_ERROR("Fused polygon is empty or degenerate");
+		}
+
+		std::vector<spk::Vector3> loop = stitchLoop(boundary, n);
+		if (loop.size() < 4)
+		{
+			GENERATE_ERROR("Fused polygon could not be stitched");
+		}
+
+		return Polygon::fromLoop(loop);
+	}
+
+	Polygon Polygon::fromLoop(const std::vector<spk::Vector3> &p_vs)
+	{
+		Polygon r;
+		if (p_vs.size() < 2)
+		{
+			return r;
+		}
+		for (size_t i = 1; i < p_vs.size(); ++i)
+		{
+			r._addEdge(p_vs[i - 1], p_vs[i]);
+		}
+		r._addEdge(p_vs.back(), p_vs.front());
+		return r;
+	}
+
+	Polygon Polygon::makeTri(const spk::Vector3 &p_a, const spk::Vector3 &p_b, const spk::Vector3 &p_c)
+	{
+		Polygon result;
+
+		result._addEdge(p_a, p_b);
+		result._addEdge(p_b, p_c);
+		result._addEdge(p_c, p_a);
+
+		return result;
+	}
+
+	Polygon Polygon::makeSquare(const spk::Vector3 &p_a, const spk::Vector3 &p_b, const spk::Vector3 &p_c, const spk::Vector3 &p_d)
+	{
+		Polygon result;
+
+		result._addEdge(p_a, p_b);
+		result._addEdge(p_b, p_c);
+		result._addEdge(p_c, p_d);
+		result._addEdge(p_d, p_a);
+
+		return result;
+	}
+
+	std::ostream &operator<<(std::ostream &p_os, const Polygon &p_poly)
+	{
+		p_os << "{";
+		for (size_t i = 0; i < p_poly._edges.size(); i++)
+		{
+			p_os << p_poly._edges[i];
+			if (i + 1 < p_poly._edges.size())
+			{
+				p_os << ", ";
+			}
+		}
+		p_os << "}";
+		return p_os;
+	}
+
+	std::wostream &operator<<(std::wostream &p_wos, const Polygon &p_poly)
+	{
+		p_wos << L"{";
+		for (size_t i = 0; i < p_poly._edges.size(); i++)
+		{
+			p_wos << p_poly._edges[i];
+			if (i + 1 < p_poly._edges.size())
+			{
+				p_wos << L", ";
+			}
+		}
+		p_wos << L"}";
+		return p_wos;
+	}
+}
+
+namespace
+{
+	float clampf(float p_v, float p_lo, float p_hi)
+	{
+		return std::max(p_lo, std::min(p_v, p_hi));
+	}
+
+	void collectSplitTsForColinearOverlap(const spk::Edge &p_base, const spk::Edge &p_other, std::vector<float> &p_ts)
+	{
+		if (p_base.isColinear(p_other) == false)
+		{
+			return;
+		}
+
+		const float len2 = p_base.delta().dot(p_base.delta());
+		if (FLOAT_EQ(len2, 0.0f) == true)
+		{
+			return;
+		}
+
+		float t0 = p_base.project(p_other.first());
+		float t1 = p_base.project(p_other.second());
+		if (t1 < t0)
+		{
+			std::swap(t0, t1);
+		}
+
+		float lo = clampf(t0, 0.0f, len2);
+		float hi = clampf(t1, 0.0f, len2);
+
+		if (FLOAT_NEQ(hi - lo, 0.0f) == true)
+		{
+			p_ts.push_back(lo);
+			p_ts.push_back(hi);
+		}
+	}
+
+	void collectSplitTsForIntersection(const spk::Edge &p_base, const spk::Edge &p_other, const spk::Vector3 &p_normal, std::vector<float> &p_ts)
+	{
+		if (p_base.isColinear(p_other) == true)
+		{
+			return;
+		}
+
+		spk::Vector3 r = p_base.delta();
+		spk::Vector3 s = p_other.delta();
+		spk::Vector3 qp = p_other.first() - p_base.first();
+
+		float denom = r.cross(s).dot(p_normal);
+		if (FLOAT_EQ(denom, 0.0f) == true)
+		{
+			return;
+		}
+
+		float t = qp.cross(s).dot(p_normal) / denom;
+		float u = qp.cross(r).dot(p_normal) / denom;
+
+		const float eps = 1e-6f;
+		if (t > eps && t < 1.0f - eps && u >= -eps && u <= 1.0f + eps)
+		{
+			spk::Vector3 inter = p_base.first() + r * t;
+			p_ts.push_back(p_base.project(inter));
+		}
+	}
+
+	void splitEdgeByTs(const spk::Edge &p_e, const std::vector<float> &p_ts, std::vector<spk::Edge> &p_out)
+	{
+		const float len = p_e.delta().norm();
+		const float len2 = len * len;
+		if (FLOAT_EQ(len, 0.0f) == true)
+		{
+			return;
+		}
+		if (p_ts.empty())
+		{
+			p_out.push_back(p_e);
+			return;
+		}
+
+		std::vector<float> cuts = p_ts;
+		cuts.push_back(0.0f);
+		cuts.push_back(len2);
+		std::sort(cuts.begin(), cuts.end());
+		cuts.erase(std::unique(cuts.begin(), cuts.end(), [](float p_a, float p_b) { return FLOAT_EQ(p_a, p_b) == true; }), cuts.end());
+
+		for (size_t i = 1; i < cuts.size(); ++i)
+		{
+			float t0 = cuts[i - 1];
+			float t1 = cuts[i];
+			if (FLOAT_EQ(t1 - t0, 0.0f) == true)
+			{
+				continue;
+			}
+
+			float alpha0 = std::max(0.0f, std::min(1.0f, t0 / len2));
+			float alpha1 = std::max(0.0f, std::min(1.0f, t1 / len2));
+
+			spk::Vector3 A = p_e.first() + p_e.delta() * alpha0;
+			spk::Vector3 B = p_e.first() + p_e.delta() * alpha1;
+			if (FLOAT_EQ((B - A).norm(), 0.0f) == true)
+			{
+				continue;
+			}
+
+			p_out.emplace_back(A, B);
+		}
+	}
+
+	void splitAllEdges(std::vector<spk::Edge> &p_base, const std::vector<spk::Edge> &p_other, const spk::Vector3 &p_normal)
+	{
+		std::vector<spk::Edge> result;
+		for (const auto &e : p_base)
+		{
+			std::vector<float> ts;
+			for (const auto &o : p_other)
+			{
+				collectSplitTsForColinearOverlap(e, o, ts);
+				collectSplitTsForIntersection(e, o, p_normal, ts);
+			}
+
+			splitEdgeByTs(e, ts, result);
+		}
+		p_base = result;
+	}
+
+	std::vector<spk::Edge> subtractInternalShared(const std::vector<spk::Edge> &p_a, const std::vector<spk::Edge> &p_b)
+	{
+		std::vector<spk::Edge> out;
+		for (const auto &ea : p_a)
+		{
+			bool inside = false;
+			for (const auto &eb : p_b)
+			{
+				if (ea.isColinear(eb) == true && eb.contains(ea.first()) == true && eb.contains(ea.second()) == true)
+				{
+					inside = true;
+					break;
+				}
+			}
+			if (inside == false)
+			{
+				out.push_back(ea);
+			}
+		}
+		return out;
+	}
+
+	std::vector<spk::Vector3> stitchLoop(const std::vector<spk::Edge> &p_edges, const spk::Vector3 &p_normal)
+	{
+		if (p_edges.empty())
+		{
+			return {};
+		}
+
+		std::map<spk::Vector3, spk::Vector2> coords;
+		spk::Vector3 u = p_edges[0].delta().normalize();
+		spk::Vector3 v = p_normal.cross(u);
+		for (const auto &e : p_edges)
+		{
+			if (coords.find(e.first()) == coords.end())
+			{
+				coords[e.first()] = spk::Vector2(e.first().dot(u), e.first().dot(v));
+			}
+			if (coords.find(e.second()) == coords.end())
+			{
+				coords[e.second()] = spk::Vector2(e.second().dot(u), e.second().dot(v));
+			}
+		}
+
+		spk::Vector3 start = p_edges[0].first();
+		spk::Vector2 startCoord = coords[start];
+		for (const auto &e : p_edges)
+		{
+			spk::Vector2 c = coords[e.first()];
+			if (c.y < startCoord.y || (FLOAT_EQ(c.y, startCoord.y) == true && c.x < startCoord.x))
+			{
+				start = e.first();
+				startCoord = c;
+			}
+			c = coords[e.second()];
+			if (c.y < startCoord.y || (FLOAT_EQ(c.y, startCoord.y) == true && c.x < startCoord.x))
+			{
+				start = e.second();
+				startCoord = c;
+			}
+		}
+
+		std::vector<std::pair<size_t, bool>> unused;
+		unused.reserve(p_edges.size());
+		for (size_t i = 0; i < p_edges.size(); ++i)
+		{
+			unused.emplace_back(i, true);
+			unused.emplace_back(i, false);
+		}
+
+		std::vector<std::vector<std::pair<size_t, bool>>> adj(coords.size());
+		std::map<spk::Vector3, size_t> index;
+		{
+			std::vector<spk::Vector3> verts;
+			verts.reserve(coords.size());
+			for (auto &kv : coords)
+			{
+				index[kv.first] = verts.size();
+				verts.push_back(kv.first);
+			}
+			for (size_t i = 0; i < p_edges.size(); ++i)
+			{
+				spk::Vector3 a = p_edges[i].first();
+				spk::Vector3 b = p_edges[i].second();
+				size_t ia = index[a];
+				size_t ib = index[b];
+				adj[ia].emplace_back(i, true);
+				adj[ib].emplace_back(i, false);
+			}
+		}
+
+		std::vector<spk::Vector3> loop;
+		spk::Vector3 cur3 = start;
+		spk::Vector2 curCoord = coords[cur3];
+		spk::Vector2 curDir(1.0f, 0.0f);
+
+		std::vector<bool> used(p_edges.size(), false);
+
+		loop.push_back(cur3);
+		while (true)
+		{
+			float bestAng = -std::numeric_limits<float>::infinity();
+			size_t bestIdx = SIZE_MAX;
+			bool bestForward = true;
+			for (auto &opt : adj[index[cur3]])
+			{
+				size_t idx = opt.first;
+				bool forward = opt.second;
+				if (used[idx] == true)
+				{
+					continue;
+				}
+				spk::Vector3 next3 = forward == true ? p_edges[idx].second() : p_edges[idx].first();
+				spk::Vector2 dir = (coords[next3] - coords[cur3]).normalize();
+				float cross = curDir.x * dir.y - curDir.y * dir.x;
+				float dot = curDir.x * dir.x + curDir.y * dir.y;
+				float ang = std::atan2(cross, dot);
+				if (ang > bestAng)
+				{
+					bestAng = ang;
+					bestIdx = idx;
+					bestForward = forward;
+				}
+			}
+			if (bestIdx == SIZE_MAX)
+			{
+				break;
+			}
+			used[bestIdx] = true;
+			spk::Vector3 next3 = bestForward == true ? p_edges[bestIdx].second() : p_edges[bestIdx].first();
+			loop.push_back(next3);
+			curDir = (coords[next3] - coords[cur3]).normalize();
+			cur3 = next3;
+			if (cur3 == start)
+			{
+				break;
+			}
+		}
+
+		if (loop.size() >= 3 && ((loop.front() == loop.back()) == false))
+		{
+			loop.push_back(loop.front());
+		}
+		return loop;
+	}
+}


### PR DESCRIPTION
## Summary
- fuse block face polygons before occlusion checks to avoid hidden geometry
- merge coplanar polygons when converting ObjMeshes to CollisionMeshes
- relax coplanarity test to compare plane offsets and prevent merging non-coplanar surfaces
- skip duplicate vertices when rebuilding polygons to avoid zero-length edges
- propagate detailed errors via try/catch in polygon fusion and collision mesh creation

## Testing
- `clang-format -i src/structure/math/spk_polygon.cpp src/structure/engine/spk_collision_mesh.cpp`
- `clang-tidy src/structure/math/spk_polygon.cpp -- -std=c++17 -Iinclude` (fails: 'GL/glew.h' file not found)
- `clang-tidy src/structure/engine/spk_collision_mesh.cpp -- -std=c++17 -Iinclude` (fails: 'GL/glew.h' file not found)
- `cmake --preset test-debug` (fails: could not find toolchain file and Ninja missing)
- `cmake --build --preset test-debug` (fails: No such file or directory)
- `ctest --preset test-debug` (no tests were found)


------
https://chatgpt.com/codex/tasks/task_e_68ae002677a4832584f21d644b44cbe5