### PR TITLE
Fix coplanar detection in playground collision mesh

### DIFF
--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -256,7 +256,15 @@ namespace tmp
 			spk::Vector3 currentNormal = normal();
 			spk::Vector3 otherNormal = p_other.normal();
 
-			return ((currentNormal == otherNormal || currentNormal.inverse() == otherNormal) && currentNormal.dot(p_other.edges()[0].first()) == 0);
+			if ((currentNormal == otherNormal || currentNormal.inverse() == otherNormal) == false)
+			{
+				return (false);
+			}
+
+			float currentOffset = currentNormal.dot(_edges[0].first());
+			float otherOffset = currentNormal.dot(p_other.edges()[0].first());
+
+			return (FLOAT_EQ(currentOffset, otherOffset) == true);
 		}
 
 		bool isAdjacent(const Polygon &p_other) const


### PR DESCRIPTION
## Summary
- fix coplanar test in temporary collision mesh so interior faces are removed

## Testing
- `cmake --preset test-debug` *(fails: Could not find toolchain file: C:/vcpkg/scripts/buildsystems/vcpkg.cmake)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(fails: No tests were found!!!)*
- `clang-tidy playground/src/main.cpp -p build/test-debug` *(fails: Could not auto-detect compilation database)*

------
https://chatgpt.com/codex/tasks/task_e_68ae241ac59c83259447c0803d3b5103