### PR TITLE
Fix polygon fusion boundary to include edges from both polygons

### DIFF
--- a/src/structure/math/spk_polygon.cpp
+++ b/src/structure/math/spk_polygon.cpp
@@ -413,6 +413,8 @@ namespace spk
 		splitAllEdges(A, B, n);
 		splitAllEdges(B, A, n);
 		std::vector<spk::Edge> boundary = subtractInternalShared(A, B);
+		std::vector<spk::Edge> uniqueB = subtractInternalShared(B, A);
+		boundary.insert(boundary.end(), uniqueB.begin(), uniqueB.end());
 		if (boundary.empty())
 		{
 			GENERATE_ERROR("Fused polygon is empty or degenerate");


### PR DESCRIPTION
## Summary
- Ensure polygon fusion includes unique edges from both input polygons

## Testing
- `clang-format -i src/structure/math/spk_polygon.cpp`
- `clang-tidy src/structure/math/spk_polygon.cpp -p build/test-debug` *(fails: could not auto-detect compilation database)*
- `cmake --preset test-debug` *(fails: Could not find toolchain file and missing Ninja)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec8b4fa0c832588c2c8713ac5964d