### PR TITLE
Handle undersized fused polygons

### DIFF
--- a/src/structure/math/spk_polygon.cpp
+++ b/src/structure/math/spk_polygon.cpp
@@ -443,6 +443,7 @@ namespace spk
 		if (loop.size() < 4)
 		{
 			GENERATE_ERROR("Fused polygon could not be stitched (Loop size : " + std::to_string(loop.size()) + ")");
+			return spk::Polygon();
 		}
 		return spk::Polygon::fromLoop(loop);
 	}


### PR DESCRIPTION
## Summary
- Prevent crashes when fusing polygons by returning an empty polygon if stitch loop has fewer than four points, while preserving diagnostics.

## Testing
- `clang-tidy src/structure/math/spk_polygon.cpp -- -Iinclude` *(fails: GL/glew.h file not found)*
- `cmake --preset test-debug` *(fails: Could not find toolchain file and Ninja)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed0e7e4a08325a1b5afd50ce29bc2