### PR TITLE
Sort collision polygons by reference frame

### DIFF
--- a/include/structure/math/spk_plane.hpp
+++ b/include/structure/math/spk_plane.hpp
@@ -33,24 +33,27 @@ namespace spk
 
 		bool contains(const spk::Vector3 &p_point) const
 		{
-			return (std::abs(normal.dot(p_point - origin)) <= spk::Constants::angularPrecision);
+			return (std::abs(normal.dot(p_point - origin)) <= spk::Constants::pointPrecision);
 		}
 
-		bool operator == (const spk::Plane &p_plane) const
+		bool operator==(const spk::Plane &p_plane) const
 		{
-			if (normal != p_plane.normal && normal != -p_plane.normal)
+			spk::Vector3 n = normal.normalize();
+			spk::Vector3 otherN = p_plane.normal.normalize();
+
+			if ((n != otherN) == true && (n != -otherN) == true)
 			{
 				return (false);
 			}
-			return (contains(p_plane.origin));
+			return ((origin == p_plane.origin) == true);
 		}
 
-		bool operator != (const spk::Plane &p_plane) const
+		bool operator!=(const spk::Plane &p_plane) const
 		{
 			return (!(*this == p_plane));
 		}
 
-		bool operator < (const spk::Plane &p_plane) const
+		bool operator<(const spk::Plane &p_plane) const
 		{
 			if (normal != p_plane.normal)
 			{
@@ -61,12 +64,24 @@ namespace spk
 	};
 }
 
-template<> template<> template<> struct std::hash<spk::Plane>
+namespace std
 {
-	size_t operator()(const spk::Plane &p_vec) const
+	template <>
+	struct hash<spk::Plane>
 	{
-		size_t h1 = std::hash<spk::Vector3>()(p_vec.origin);
-		size_t h2 = std::hash<spk::Vector3>()(p_vec.normal);
-		return h1 ^ (h2 << 1);
-	}
-};
+		size_t operator()(const spk::Plane &p_plane) const
+		{
+			spk::Vector3 n = p_plane.normal.normalize();
+
+			if ((-n < n) == true)
+			{
+				n = n * -1.0f;
+			}
+
+			size_t h = 0;
+			h ^= std::hash<spk::Vector3>()(n) + 0x9e3779b9 + (h << 6) + (h >> 2);
+			h ^= std::hash<spk::Vector3>()(p_plane.origin) + 0x9e3779b9 + (h << 6) + (h >> 2);
+			return (h);
+		}
+	};
+}

--- a/src/structure/engine/spk_collision_mesh.cpp
+++ b/src/structure/engine/spk_collision_mesh.cpp
@@ -1,4 +1,6 @@
 #include "structure/engine/spk_collision_mesh.hpp"
+#include "structure/math/spk_reference_frame.hpp"
+#include <unordered_map>
 
 namespace spk
 {
@@ -15,15 +17,77 @@ namespace spk
 	CollisionMesh CollisionMesh::fromObjMesh(const spk::SafePointer<spk::ObjMesh> &p_mesh)
 	{
 		spk::CollisionMesh result;
+
+		struct ReferenceFrameHash
+		{
+			std::size_t operator()(const spk::ReferenceFrame &p_frame) const noexcept
+			{
+				spk::Vector3 normal = p_frame.zAxis().normalize();
+				if ((normal.x < 0.0f) == true || (FLOAT_EQ(normal.x, 0.0f) == true &&
+												  ((normal.y < 0.0f) == true || (FLOAT_EQ(normal.y, 0.0f) == true && (normal.z < 0.0f) == true))))
+				{
+					normal = normal * -1.0f;
+				}
+				const float d = normal.dot(p_frame.origin());
+				std::size_t h1 = std::hash<spk::Vector3>()(normal);
+				std::size_t h2 = std::hash<float>()(d);
+				return h1 ^ (h2 << 1);
+			}
+		};
+
+		struct ReferenceFrameEqual
+		{
+			bool operator()(const spk::ReferenceFrame &p_a, const spk::ReferenceFrame &p_b) const noexcept
+			{
+				spk::Vector3 normalA = p_a.zAxis().normalize();
+				spk::Vector3 normalB = p_b.zAxis().normalize();
+
+				if ((normalA.x < 0.0f) == true || (FLOAT_EQ(normalA.x, 0.0f) == true &&
+												   ((normalA.y < 0.0f) == true || (FLOAT_EQ(normalA.y, 0.0f) == true && (normalA.z < 0.0f) == true))))
+				{
+					normalA = normalA * -1.0f;
+				}
+				if ((normalB.x < 0.0f) == true || (FLOAT_EQ(normalB.x, 0.0f) == true &&
+												   ((normalB.y < 0.0f) == true || (FLOAT_EQ(normalB.y, 0.0f) == true && (normalB.z < 0.0f) == true))))
+				{
+					normalB = normalB * -1.0f;
+				}
+				if ((normalA != normalB) == true)
+				{
+					return false;
+				}
+				const float dA = normalA.dot(p_a.origin());
+				const float dB = normalB.dot(p_b.origin());
+				return (FLOAT_EQ(dA, dB) == true);
+			}
+		};
+
+		std::unordered_map<spk::ReferenceFrame, std::vector<spk::Polygon>, ReferenceFrameHash, ReferenceFrameEqual> polygonsByFrame;
+
 		for (const auto &shape : p_mesh->shapes())
 		{
-			spk::CollisionMesh::Unit unit;
+			spk::CollisionMesh::Unit polygon;
 			for (const auto &vertex : shape.points)
 			{
-				unit.points.push_back(vertex.position);
+				polygon.points.push_back(vertex.position);
 			}
-			result.addUnit(unit);
+			if (polygon.isPlanar() == true)
+			{
+				spk::ReferenceFrame frame(polygon.plane());
+				spk::Polygon localPolygon = frame.convertTo(polygon);
+				polygonsByFrame[frame].push_back(localPolygon);
+			}
 		}
+
+		for (const auto &[frame, polygons] : polygonsByFrame)
+		{
+			for (const auto &localPolygon : polygons)
+			{
+				spk::Polygon worldPolygon = frame.convertFrom(localPolygon);
+				result.addUnit(worldPolygon);
+			}
+		}
+
 		return (result);
 	}
 }


### PR DESCRIPTION
## Summary
- group OBJ mesh polygons by planar reference frame
- convert polygons to and from their local frames during collision mesh build
- account for plane origins when comparing and hashing planes

## Testing
- `clang-format -i include/structure/math/spk_plane.hpp`
- `clang-tidy include/structure/math/spk_plane.hpp -- -Iinclude -std=c++20` *(fails: 'GL/glew.h' file not found)*
- `cmake --preset test-debug` *(fails: Could not find toolchain file C:/vcpkg/scripts/buildsystems/vcpkg.cmake; Ninja not found)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68aefeb0e8a08325a3e8cbee2069c5e4