### PR TITLE
Fix polygon contains to include boundary points

### DIFF
--- a/src/structure/math/spk_polygon.cpp
+++ b/src/structure/math/spk_polygon.cpp
@@ -38,14 +38,14 @@ namespace spk
 
 			if (orient > 0)
 			{
-				if (val <= p_eps)
+				if (val < -p_eps)
 				{
 					return false;
 				}
 			}
 			else
 			{
-				if (val >= -p_eps)
+				if (val > p_eps)
 				{
 					return false;
 				}


### PR DESCRIPTION
## Summary
- treat boundary points as inside polygons when checking point inclusion
- fixes face occlusion logic relying on polygon containment

## Testing
- `clang-format -i src/structure/math/spk_polygon.cpp`
- `clang-tidy src/structure/math/spk_polygon.cpp -p build/test-debug` (fails: no compilation database)
- `cmake --preset test-debug` (fails: missing vcpkg toolchain and Ninja)
- `cmake --build --preset test-debug` (fails: no such file or directory)
- `ctest --preset test-debug` (fails: no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b0221f1b0083259a778965d2d18563