### PR TITLE
feat: add tag filtering to ray casts

### DIFF
--- a/include/structure/engine/spk_ray_cast.hpp
+++ b/include/structure/engine/spk_ray_cast.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <span>
+#include <string>
 #include <vector>
 
 #include "structure/engine/spk_entity.hpp"
 #include "structure/engine/spk_game_engine.hpp"
 #include "structure/math/spk_vector3.hpp"
+#include "structure/system/spk_boolean_enum.hpp"
 
 namespace spk
 {
@@ -18,11 +21,31 @@ namespace spk
 		};
 
 		static Hit launch(
-			const spk::SafePointer<spk::GameEngine> &p_engine, const spk::Vector3 &p_eye, const spk::Vector3 &p_direction, float p_maxDistance);
+			const spk::SafePointer<spk::GameEngine> &p_engine,
+			const spk::Vector3 &p_eye,
+			const spk::Vector3 &p_direction,
+			float p_maxDistance,
+			std::span<const std::wstring> p_tags = {},
+			spk::BinaryOperator p_binaryOperator = spk::BinaryOperator::AND);
 		static std::vector<Hit> launchAll(
-			const spk::SafePointer<spk::GameEngine> &p_engine, const spk::Vector3 &p_eye, const spk::Vector3 &p_direction, float p_maxDistance);
+			const spk::SafePointer<spk::GameEngine> &p_engine,
+			const spk::Vector3 &p_eye,
+			const spk::Vector3 &p_direction,
+			float p_maxDistance,
+			std::span<const std::wstring> p_tags = {},
+			spk::BinaryOperator p_binaryOperator = spk::BinaryOperator::AND);
 
-		static Hit launch(const spk::SafePointer<spk::Entity> &p_entity, const spk::Vector3 &p_direction, float p_maxDistance);
-		static std::vector<Hit> launchAll(const spk::SafePointer<spk::Entity> &p_entity, const spk::Vector3 &p_direction, float p_maxDistance);
+		static Hit launch(
+			const spk::SafePointer<spk::Entity> &p_entity,
+			const spk::Vector3 &p_direction,
+			float p_maxDistance,
+			std::span<const std::wstring> p_tags = {},
+			spk::BinaryOperator p_binaryOperator = spk::BinaryOperator::AND);
+		static std::vector<Hit> launchAll(
+			const spk::SafePointer<spk::Entity> &p_entity,
+			const spk::Vector3 &p_direction,
+			float p_maxDistance,
+			std::span<const std::wstring> p_tags = {},
+			spk::BinaryOperator p_binaryOperator = spk::BinaryOperator::AND);
 	};
 }

--- a/include/structure/engine/spk_ray_cast_2d.hpp
+++ b/include/structure/engine/spk_ray_cast_2d.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <span>
+#include <string>
 #include <vector>
 
 #include "structure/engine/spk_entity.hpp"
 #include "structure/math/spk_vector2.hpp"
+#include "structure/system/spk_boolean_enum.hpp"
 
 namespace spk
 {
@@ -16,9 +19,18 @@ namespace spk
 			spk::SafePointer<spk::Entity> entity;
 		};
 
-		static Hit launch(const spk::SafePointer<spk::Entity> &p_cameraEntity, const spk::Vector2 &p_screenPosition, float p_maxDistance);
+		static Hit launch(
+			const spk::SafePointer<spk::Entity> &p_cameraEntity,
+			const spk::Vector2 &p_screenPosition,
+			float p_maxDistance,
+			std::span<const std::wstring> p_tags = {},
+			spk::BinaryOperator p_binaryOperator = spk::BinaryOperator::AND);
 		static std::vector<Hit> launchAll(
-			const spk::SafePointer<spk::Entity> &p_cameraEntity, const spk::Vector2 &p_screenPosition, float p_maxDistance);
+			const spk::SafePointer<spk::Entity> &p_cameraEntity,
+			const spk::Vector2 &p_screenPosition,
+			float p_maxDistance,
+			std::span<const std::wstring> p_tags = {},
+			spk::BinaryOperator p_binaryOperator = spk::BinaryOperator::AND);
 
 		static spk::Vector2 screenPointToWorld(
 			const spk::SafePointer<spk::Entity> &p_cameraEntity, const spk::Vector2 &p_screenPosition, float p_layer);

--- a/src/structure/engine/spk_ray_cast.cpp
+++ b/src/structure/engine/spk_ray_cast.cpp
@@ -107,6 +107,8 @@ namespace
 		const spk::Vector3 &p_eye,
 		const spk::Vector3 &p_dir,
 		float p_maxDistance,
+		std::span<const std::wstring> p_tags,
+		spk::BinaryOperator p_binaryOperator,
 		std::vector<spk::RayCast::Hit> &p_hits)
 	{
 		if ((p_body == nullptr) == true)
@@ -118,6 +120,13 @@ namespace
 		{
 			return;
 		}
+		if ((p_tags.empty() == false))
+		{
+			if ((owner->containsTags(p_tags, p_binaryOperator) == false))
+			{
+				return;
+			}
+		}
 		spk::Vector3 offset = owner->transform().position();
 		processCollider(p_body->collider(), p_eye, p_dir, p_maxDistance, offset, owner, p_hits);
 	}
@@ -126,9 +135,14 @@ namespace
 namespace spk
 {
 	RayCast::Hit RayCast::launch(
-		const spk::SafePointer<spk::GameEngine> &p_engine, const spk::Vector3 &p_eye, const spk::Vector3 &p_direction, float p_maxDistance)
+		const spk::SafePointer<spk::GameEngine> &p_engine,
+		const spk::Vector3 &p_eye,
+		const spk::Vector3 &p_direction,
+		float p_maxDistance,
+		std::span<const std::wstring> p_tags,
+		spk::BinaryOperator p_binaryOperator)
 	{
-		std::vector<Hit> hits = launchAll(p_engine, p_eye, p_direction, p_maxDistance);
+		std::vector<Hit> hits = launchAll(p_engine, p_eye, p_direction, p_maxDistance, p_tags, p_binaryOperator);
 		Hit result{};
 		float closest = p_maxDistance;
 		for (const auto &hit : hits)
@@ -144,7 +158,12 @@ namespace spk
 	}
 
 	std::vector<RayCast::Hit> RayCast::launchAll(
-		const spk::SafePointer<spk::GameEngine> &p_engine, const spk::Vector3 &p_eye, const spk::Vector3 &p_direction, float p_maxDistance)
+		const spk::SafePointer<spk::GameEngine> &p_engine,
+		const spk::Vector3 &p_eye,
+		const spk::Vector3 &p_direction,
+		float p_maxDistance,
+		std::span<const std::wstring> p_tags,
+		spk::BinaryOperator p_binaryOperator)
 	{
 		std::vector<Hit> hits;
 		if ((p_engine == nullptr) == true)
@@ -155,26 +174,36 @@ namespace spk
 		std::vector<spk::SafePointer<spk::RigidBody>> bodies = spk::RigidBody::getRigidBodies();
 		for (const auto &body : bodies)
 		{
-			processBody(body, p_engine, p_eye, dir, p_maxDistance, hits);
+			processBody(body, p_engine, p_eye, dir, p_maxDistance, p_tags, p_binaryOperator, hits);
 		}
 		return hits;
 	}
 
-	RayCast::Hit RayCast::launch(const spk::SafePointer<spk::Entity> &p_entity, const spk::Vector3 &p_direction, float p_maxDistance)
+	RayCast::Hit RayCast::launch(
+		const spk::SafePointer<spk::Entity> &p_entity,
+		const spk::Vector3 &p_direction,
+		float p_maxDistance,
+		std::span<const std::wstring> p_tags,
+		spk::BinaryOperator p_binaryOperator)
 	{
 		if ((p_entity == nullptr) == true)
 		{
 			return {};
 		}
-		return launch(p_entity->engine(), p_entity->transform().position(), p_direction, p_maxDistance);
+		return launch(p_entity->engine(), p_entity->transform().position(), p_direction, p_maxDistance, p_tags, p_binaryOperator);
 	}
 
-	std::vector<RayCast::Hit> RayCast::launchAll(const spk::SafePointer<spk::Entity> &p_entity, const spk::Vector3 &p_direction, float p_maxDistance)
+	std::vector<RayCast::Hit> RayCast::launchAll(
+		const spk::SafePointer<spk::Entity> &p_entity,
+		const spk::Vector3 &p_direction,
+		float p_maxDistance,
+		std::span<const std::wstring> p_tags,
+		spk::BinaryOperator p_binaryOperator)
 	{
 		if ((p_entity == nullptr) == true)
 		{
 			return {};
 		}
-		return launchAll(p_entity->engine(), p_entity->transform().position(), p_direction, p_maxDistance);
+		return launchAll(p_entity->engine(), p_entity->transform().position(), p_direction, p_maxDistance, p_tags, p_binaryOperator);
 	}
 }


### PR DESCRIPTION
## Summary
- allow `RayCast` and `RayCast2D` to filter hits by entity tags using a `BinaryOperator`
- use `Entity::containsTags` to honor AND/OR combinations

## Testing
- `clang-tidy include/structure/engine/spk_ray_cast.hpp include/structure/engine/spk_ray_cast_2d.hpp src/structure/engine/spk_ray_cast.cpp src/structure/engine/spk_ray_cast_2d.cpp -p build/test-debug` *(failed: Could not auto-detect compilation database)*
- `cmake --preset test-debug` *(failed: Could not find toolchain file /scripts/buildsystems/vcpkg.cmake; Ninja missing)*
- `cmake --build --preset test-debug` *(failed: No such file or directory)*
- `ctest --preset test-debug` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68b95e20a378832599e66a68f03dbdf8