### PR TITLE
Implement lazy collision mesh generation

### DIFF
--- a/include/structure/spk_cached_data.hpp
+++ b/include/structure/spk_cached_data.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+namespace spk
+{
+	template <typename TType>
+	class CachedData
+	{
+	public:
+		using Generator = std::function<TType()>;
+
+	private:
+		Generator _generator;
+		mutable std::unique_ptr<TType> _data;
+
+	public:
+		CachedData(Generator p_generator) :
+			_generator(p_generator)
+		{
+		}
+
+		TType &get() const
+		{
+			if (_data == nullptr)
+			{
+				_data = std::make_unique<TType>(_generator());
+			}
+			return *_data;
+		}
+
+		TType &operator*() const
+		{
+			return get();
+		}
+
+		void release() const
+		{
+			_data.reset();
+		}
+	};
+}


### PR DESCRIPTION
## Summary
- Add templated `CachedData` utility for lazy data creation and release
- Cache each chunk's `CollisionMesh2D` and regenerate only on demand
- Reset chunk collision caches when tilemap collision flags change

## Testing
- `clang-format -i include/structure/spk_cached_data.hpp include/structure/engine/spk_tile_map.hpp`
- `clang-tidy include/structure/spk_cached_data.hpp include/structure/engine/spk_tile_map.hpp -- -std=c++20` *(fails: 5710 warnings and 1 error)*
- `cmake --preset test-debug` *(fails: Could not find toolchain file /scripts/buildsystems/vcpkg.cmake; Ninja not found)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9e02c4e483259cbe97d955dcda5d