### PR TITLE
Add F1 toggle to view collision meshes

### DIFF
--- a/include/structure/engine/spk_tile_map.hpp
+++ b/include/structure/engine/spk_tile_map.hpp
@@ -676,6 +676,16 @@ namespace spk
 				return _data->bakeCollisionMesh(p_flags);
 			}
 
+			spk::SafePointer<Mesh2DRenderer> renderer()
+			{
+				return _renderer;
+			}
+
+			spk::SafePointer<const Mesh2DRenderer> renderer() const
+			{
+				return _renderer;
+			}
+
 			using EditionContract = spk::ContractProvider::Contract;
 			EditionContract onEdition(const spk::ContractProvider::Job &p_job)
 			{

--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -63,6 +63,37 @@ private:
 				_editionContract = _chunk->onEdition([this]() { _bake(); });
 			}
 		}
+
+		void onKeyboardEvent(spk::KeyboardEvent &p_event) override
+		{
+			if (p_event.type == spk::KeyboardEvent::Type::Press && p_event.key == spk::Keyboard::F1)
+			{
+				if (_renderer != nullptr)
+				{
+					spk::SafePointer<spk::Mesh2DRenderer> chunkRenderer;
+					if (_chunk != nullptr)
+					{
+						chunkRenderer = _chunk->renderer();
+					}
+					if (_renderer->isActive() == true)
+					{
+						_renderer->deactivate();
+						if (chunkRenderer != nullptr)
+						{
+							chunkRenderer->activate();
+						}
+					}
+					else
+					{
+						_renderer->activate();
+						if (chunkRenderer != nullptr)
+						{
+							chunkRenderer->deactivate();
+						}
+					}
+				}
+			}
+		}
 	};
 
 	short _tileIdFromNoise(float p_value) const


### PR DESCRIPTION
## Summary
- Remove unused chunk renderer setter and expose renderer via a getter
- Toggle collision vs tile rendering by checking the collision renderer's active state

## Testing
- `cmake --preset test-debug` *(fails: Could not find toolchain file /scripts/buildsystems/vcpkg.cmake; CMake was unable to find a build program corresponding to "Ninja")*
- `cmake --build --preset test-debug` *(fails: No such file or directory; Generator: execution of make failed)*
- `ctest --preset test-debug` *(fails: No tests were found)*
- `clang-tidy playground/src/main.cpp include/structure/engine/spk_tile_map.hpp -p build/test-debug` *(fails: Could not auto-detect compilation database; found compiler errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1f91bb248325965409ff84a6bb87