### PR TITLE
Refactor collision rendering toggle into component

### DIFF
--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -183,29 +183,51 @@ public:
 		_perlin.setInterpolation(spk::Perlin::Interpolation::SmoothStep);
 
 		_perlin.setSeed(1337u);
+		addComponent<CollisionRenderingToggle>(name() + L"/CollisionRenderingToggle", this);
 	}
 
-	void onKeyboardEvent(spk::KeyboardEvent &p_event) override
+	bool collisionRendering() const
 	{
-		if (p_event.type == spk::KeyboardEvent::Type::Press && p_event.key == spk::Keyboard::F1)
-		{
-			if (_collisionRenderActive == true)
-			{
-				_setCollisionRendering(false);
-			}
-			else
-			{
-				_setCollisionRendering(true);
-			}
-		}
+		return _collisionRenderActive;
 	}
 
-private:
-	void _setCollisionRendering(bool p_state)
+	void setCollisionRendering(bool p_state)
 	{
 		_collisionRenderActive = p_state;
 		_collisionRenderingContractProvider.trigger(_collisionRenderActive);
 	}
+
+private:
+	class CollisionRenderingToggle : public spk::Component
+	{
+	private:
+		spk::SafePointer<PlaygroundTileMap> _tileMap;
+
+	public:
+		CollisionRenderingToggle(const std::wstring &p_name, spk::SafePointer<PlaygroundTileMap> p_tileMap) :
+			spk::Component(p_name),
+			_tileMap(p_tileMap)
+		{
+		}
+
+		void onKeyboardEvent(spk::KeyboardEvent &p_event) override
+		{
+			if (p_event.type == spk::KeyboardEvent::Type::Press && p_event.key == spk::Keyboard::F1)
+			{
+				if (_tileMap != nullptr)
+				{
+					if (_tileMap->collisionRendering() == true)
+					{
+						_tileMap->setCollisionRendering(false);
+					}
+					else
+					{
+						_tileMap->setCollisionRendering(true);
+					}
+				}
+			}
+		}
+	};
 };
 
 class TileMapChunkStreamer : public spk::Component


### PR DESCRIPTION
## Summary
- Replace non-overridable onKeyboardEvent override with CollisionRenderingToggle component to handle F1 collision rendering
- Expose collision rendering controls on PlaygroundTileMap for component interaction

## Testing
- `cmake --preset test-debug` *(fails: Could not find toolchain file /scripts/buildsystems/vcpkg.cmake; CMake was unable to find a build program corresponding to "Ninja")*
- `clang-tidy playground/src/main.cpp` *(fails: Could not auto-detect compilation database for file; 1593 warnings and 1 error generated)*
- `cmake --build --preset test-debug` *(fails: No such file or directory; Generator: execution of make failed)*
- `ctest --preset test-debug` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6448cb5083258d3f3350686cbe07