### PR TITLE
Refactor shader constant management

### DIFF
--- a/include/structure/graphics/lumina/spk_shader.hpp
+++ b/include/structure/graphics/lumina/spk_shader.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <regex>
 #include <string>
 #include <unordered_map>
@@ -17,10 +18,10 @@ namespace spk::Lumina
 	class Shader
 	{
 	private:
-		using Unit = std::variant<OpenGL::SamplerObject, OpenGL::UniformBufferObject, OpenGL::ShaderStorageBufferObject>;
-		using SafeUnit = std::variant<spk::SafePointer<OpenGL::SamplerObject>,
-									  spk::SafePointer<OpenGL::UniformBufferObject>,
-									  spk::SafePointer<OpenGL::ShaderStorageBufferObject>>;
+		using Unit = std::variant<
+			std::shared_ptr<OpenGL::SamplerObject>,
+			std::shared_ptr<OpenGL::UniformBufferObject>,
+			std::shared_ptr<OpenGL::ShaderStorageBufferObject>>;
 
 	public:
 		enum class Mode
@@ -30,9 +31,9 @@ namespace spk::Lumina
 		};
 
 		template <typename Var, typename F>
-		static void visitVariant(Var &variant, F &&function)
+		static void visitVariant(Var &p_variant, F &&p_function)
 		{
-			std::visit([&](auto &&object) { function(object); }, variant);
+			std::visit([&](auto &&p_object) { p_function(p_object); }, p_variant);
 		}
 
 		class Object
@@ -59,7 +60,7 @@ namespace spk::Lumina
 
 				for (auto &[name, object] : _attributes)
 				{
-					visitVariant(object, [&](auto &object) { object.activate(); });
+					visitVariant(object, [&](auto &object) { object->activate(); });
 				}
 			}
 
@@ -69,7 +70,7 @@ namespace spk::Lumina
 
 				for (auto &[name, object] : _attributes)
 				{
-					visitVariant(object, [&](auto &object) { object.deactivate(); });
+					visitVariant(object, [&](auto &object) { object->deactivate(); });
 				}
 			}
 
@@ -102,8 +103,10 @@ namespace spk::Lumina
 
 			bool containSampler(const std::wstring &p_name) const
 			{
-				return (_originator->containSampler(p_name) ||
-						(_attributes.contains(p_name) == true && std::holds_alternative<OpenGL::SamplerObject>(_attributes.at(p_name)) == true));
+				return (
+					_originator->containSampler(p_name) ||
+					(_attributes.contains(p_name) == true &&
+					 std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_attributes.at(p_name)) == true));
 			}
 
 			OpenGL::SamplerObject &sampler(const std::wstring &p_name)
@@ -115,20 +118,24 @@ namespace spk::Lumina
 						return (_originator->sampler(p_name));
 					} catch (...)
 					{
-						throw std::runtime_error("Sampler with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants or object attributes.");
+						throw std::runtime_error(
+							"Sampler with name '" + spk::StringUtils::wstringToString(p_name) +
+							"' not found in spk::Lumina::Shader constants or object attributes.");
 					}
 				}
-				if (std::holds_alternative<OpenGL::SamplerObject>(_attributes.at(p_name)) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_attributes.at(p_name)) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not a sampler object.");
 				}
-				return std::get<OpenGL::SamplerObject>(_attributes.at(p_name));
+				return *(std::get<std::shared_ptr<OpenGL::SamplerObject>>(_attributes.at(p_name)));
 			}
 
 			bool containUBO(const std::wstring &p_name) const
 			{
-				return (_originator->containUBO(p_name) || (_attributes.contains(p_name) == true &&
-															std::holds_alternative<OpenGL::UniformBufferObject>(_attributes.at(p_name)) == true));
+				return (
+					_originator->containUBO(p_name) ||
+					(_attributes.contains(p_name) == true &&
+					 std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_attributes.at(p_name)) == true));
 			}
 
 			OpenGL::UniformBufferObject &UBO(const std::wstring &p_name)
@@ -140,21 +147,24 @@ namespace spk::Lumina
 						return (_originator->UBO(p_name));
 					} catch (...)
 					{
-						throw std::runtime_error("UBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants or object attributes.");
+						throw std::runtime_error(
+							"UBO with name '" + spk::StringUtils::wstringToString(p_name) +
+							"' not found in spk::Lumina::Shader constants or object attributes.");
 					}
 				}
-				if (std::holds_alternative<OpenGL::UniformBufferObject>(_attributes.at(p_name)) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_attributes.at(p_name)) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not a UBO.");
 				}
-				return std::get<OpenGL::UniformBufferObject>(_attributes.at(p_name));
+				return *(std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(_attributes.at(p_name)));
 			}
 
 			bool containSSBO(const std::wstring &p_name) const
 			{
-				return (_originator->containSSBO(p_name) ||
-						(_attributes.contains(p_name) == true &&
-						 std::holds_alternative<OpenGL::ShaderStorageBufferObject>(_attributes.at(p_name)) == true));
+				return (
+					_originator->containSSBO(p_name) ||
+					(_attributes.contains(p_name) == true &&
+					 std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_attributes.at(p_name)) == true));
 			}
 
 			OpenGL::ShaderStorageBufferObject &SSBO(const std::wstring &p_name)
@@ -166,14 +176,16 @@ namespace spk::Lumina
 						return (_originator->SSBO(p_name));
 					} catch (...)
 					{
-						throw std::runtime_error("SSBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants or object attributes.");
+						throw std::runtime_error(
+							"SSBO with name '" + spk::StringUtils::wstringToString(p_name) +
+							"' not found in spk::Lumina::Shader constants or object attributes.");
 					}
 				}
-				if (std::holds_alternative<OpenGL::ShaderStorageBufferObject>(_attributes.at(p_name)) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_attributes.at(p_name)) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not an SSBO.");
 				}
-				return std::get<OpenGL::ShaderStorageBufferObject>(_attributes.at(p_name));
+				return *(std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_attributes.at(p_name)));
 			}
 		};
 
@@ -183,7 +195,7 @@ namespace spk::Lumina
 		// Map holding all the constants for all the shaders
 		static inline std::unordered_map<std::wstring, Unit> _objects;
 		// Map holding the constant of this specific shader instance
-		std::unordered_map<std::wstring, SafeUnit> _availableObjects;
+		std::unordered_map<std::wstring, Unit> _availableObjects;
 
 		// Buffer set for this shader instance
 		OpenGL::BufferSet _bufferSet;
@@ -220,145 +232,150 @@ namespace spk::Lumina
 			}
 		}
 
-		void addSamplerConstant(const std::wstring &p_name, const OpenGL::SamplerObject &p_object)
+		void addSamplerConstant(const std::wstring &p_name, const std::shared_ptr<OpenGL::SamplerObject> &p_object)
 		{
 			if (_objects.contains(p_name) == false)
 			{
-				_objects[p_name] = std::move(p_object);
+				_objects[p_name] = p_object;
 			}
 			else
 			{
-				if (std::holds_alternative<OpenGL::SamplerObject>(_objects[p_name]) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_objects[p_name]) == false)
 				{
-					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) +
-											 "' is already set but is not a sampler object.");
+					throw std::runtime_error(
+						"Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not a sampler object.");
 				}
 
-				spk::SafePointer<OpenGL::SamplerObject> sampler = &(std::get<OpenGL::SamplerObject>(_objects[p_name]));
+				std::shared_ptr<OpenGL::SamplerObject> sampler = std::get<std::shared_ptr<OpenGL::SamplerObject>>(_objects[p_name]);
 
 				// No size verification to compute on samplers
 			}
 
-			_availableObjects[p_name] = &(std::get<OpenGL::SamplerObject>(_objects[p_name]));
+			_availableObjects[p_name] = std::get<std::shared_ptr<OpenGL::SamplerObject>>(_objects[p_name]);
 		}
 
-		void addSamplerAttribute(const std::wstring &p_name, const OpenGL::SamplerObject &p_object)
+		void addSamplerAttribute(const std::wstring &p_name, const std::shared_ptr<OpenGL::SamplerObject> &p_object)
 		{
 			if (_attributes.contains(p_name) == true)
 			{
-				if (std::holds_alternative<OpenGL::SamplerObject>(_attributes[p_name]) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_attributes[p_name]) == false)
 				{
-					throw std::runtime_error("Attribute with name '" + spk::StringUtils::wstringToString(p_name) +
-											 "' is already set but is not a sampler object.");
+					throw std::runtime_error(
+						"Attribute with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not a sampler object.");
 				}
 
 				throw std::runtime_error("Sampler attribute with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set.");
 			}
 
-			_attributes[p_name] = std::move(p_object);
+			_attributes[p_name] = p_object;
 		}
 
-		void addUBOConstant(const std::wstring &p_name, const OpenGL::UniformBufferObject &p_object)
+		void addUBOConstant(const std::wstring &p_name, const std::shared_ptr<OpenGL::UniformBufferObject> &p_object)
 		{
 			if (_objects.contains(p_name) == false)
 			{
-				_objects[p_name] = std::move(p_object);
+				_objects[p_name] = p_object;
 			}
 			else
 			{
-				if (std::holds_alternative<OpenGL::UniformBufferObject>(_objects[p_name]) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_objects[p_name]) == false)
 				{
-					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) +
-											 "' is already set but is not an UBO.");
+					throw std::runtime_error(
+						"Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not an UBO.");
 				}
 
-				spk::SafePointer<OpenGL::UniformBufferObject> ubo = &(std::get<OpenGL::UniformBufferObject>(_objects[p_name]));
+				std::shared_ptr<OpenGL::UniformBufferObject> ubo = std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(_objects[p_name]);
 
-				if (ubo->size() != p_object.size())
+				if (ubo->size() != p_object->size())
 				{
-					throw std::runtime_error("UBO size mismatch for '" + spk::StringUtils::wstringToString(p_name) +
-											 "'. Expected: " + std::to_string(ubo->size()) + ", got: " + std::to_string(p_object.size()));
+					throw std::runtime_error(
+						"UBO size mismatch for '" + spk::StringUtils::wstringToString(p_name) + "'. Expected: " + std::to_string(ubo->size()) +
+						", got: " + std::to_string(p_object->size()));
 				}
 
-				if (ubo->bindingPoint() != p_object.bindingPoint())
+				if (ubo->bindingPoint() != p_object->bindingPoint())
 				{
-					throw std::runtime_error("UBO binding point mismatch for '" + spk::StringUtils::wstringToString(p_name) + "'. Expected: " +
-											 std::to_string(ubo->bindingPoint()) + ", got: " + std::to_string(p_object.bindingPoint()));
+					throw std::runtime_error(
+						"UBO binding point mismatch for '" + spk::StringUtils::wstringToString(p_name) +
+						"'. Expected: " + std::to_string(ubo->bindingPoint()) + ", got: " + std::to_string(p_object->bindingPoint()));
 				}
 			}
 
-			_availableObjects[p_name] = &(std::get<OpenGL::UniformBufferObject>(_objects[p_name]));
+			_availableObjects[p_name] = std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(_objects[p_name]);
 		}
 
-		void addUBOAttribute(const std::wstring &p_name, const OpenGL::UniformBufferObject &p_object)
+		void addUBOAttribute(const std::wstring &p_name, const std::shared_ptr<OpenGL::UniformBufferObject> &p_object)
 		{
 			if (_attributes.contains(p_name) == true)
 			{
-				if (std::holds_alternative<OpenGL::UniformBufferObject>(_attributes[p_name]) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_attributes[p_name]) == false)
 				{
-					throw std::runtime_error("Attribute with name '" + spk::StringUtils::wstringToString(p_name) +
-											 "' is already set but is not an UBO object.");
+					throw std::runtime_error(
+						"Attribute with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not an UBO object.");
 				}
 
 				throw std::runtime_error("UBO attribute with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set.");
 			}
 
-			_attributes[p_name] = std::move(p_object);
+			_attributes[p_name] = p_object;
 		}
 
-		void addSSBOConstant(const std::wstring &p_name, const OpenGL::ShaderStorageBufferObject &p_object)
+		void addSSBOConstant(const std::wstring &p_name, const std::shared_ptr<OpenGL::ShaderStorageBufferObject> &p_object)
 		{
 			if (_objects.contains(p_name) == false)
 			{
-				_objects[p_name] = std::move(p_object);
+				_objects[p_name] = p_object;
 			}
 			else
 			{
-				if (std::holds_alternative<OpenGL::ShaderStorageBufferObject>(_objects[p_name]) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_objects[p_name]) == false)
 				{
-					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) +
-											 "' is already set but is not an SSBO.");
+					throw std::runtime_error(
+						"Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not an SSBO.");
 				}
 
-				spk::SafePointer<OpenGL::ShaderStorageBufferObject> ssbo = &(std::get<OpenGL::ShaderStorageBufferObject>(_objects[p_name]));
+				std::shared_ptr<OpenGL::ShaderStorageBufferObject> ssbo =
+					std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_objects[p_name]);
 
-				if (ssbo->fixedData().size() != p_object.fixedData().size())
+				if (ssbo->fixedData().size() != p_object->fixedData().size())
 				{
-					throw std::runtime_error("SSBO fixed data size mismatch for '" + spk::StringUtils::wstringToString(p_name) + "'. Expected: " +
-											 std::to_string(ssbo->fixedData().size()) + ", got: " + std::to_string(p_object.fixedData().size()));
+					throw std::runtime_error(
+						"SSBO fixed data size mismatch for '" + spk::StringUtils::wstringToString(p_name) +
+						"'. Expected: " + std::to_string(ssbo->fixedData().size()) + ", got: " + std::to_string(p_object->fixedData().size()));
 				}
 
-				if (ssbo->dynamicArray().elementSize() != p_object.dynamicArray().elementSize())
+				if (ssbo->dynamicArray().elementSize() != p_object->dynamicArray().elementSize())
 				{
-					throw std::runtime_error("SSBO dynamic array element size mismatch for '" + spk::StringUtils::wstringToString(p_name) +
-											 "'. Expected: " + std::to_string(ssbo->dynamicArray().elementSize()) +
-											 ", got: " + std::to_string(p_object.dynamicArray().elementSize()));
+					throw std::runtime_error(
+						"SSBO dynamic array element size mismatch for '" + spk::StringUtils::wstringToString(p_name) + "'. Expected: " +
+						std::to_string(ssbo->dynamicArray().elementSize()) + ", got: " + std::to_string(p_object->dynamicArray().elementSize()));
 				}
 
-				if (ssbo->bindingPoint() != p_object.bindingPoint())
+				if (ssbo->bindingPoint() != p_object->bindingPoint())
 				{
-					throw std::runtime_error("SSBO binding point mismatch for '" + spk::StringUtils::wstringToString(p_name) + "'. Expected: " +
-											 std::to_string(ssbo->bindingPoint()) + ", got: " + std::to_string(p_object.bindingPoint()));
+					throw std::runtime_error(
+						"SSBO binding point mismatch for '" + spk::StringUtils::wstringToString(p_name) +
+						"'. Expected: " + std::to_string(ssbo->bindingPoint()) + ", got: " + std::to_string(p_object->bindingPoint()));
 				}
 			}
 
-			_availableObjects[p_name] = &(std::get<OpenGL::ShaderStorageBufferObject>(_objects[p_name]));
+			_availableObjects[p_name] = std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_objects[p_name]);
 		}
 
-		void addSSBOAttribute(const std::wstring &p_name, const OpenGL::ShaderStorageBufferObject &p_object)
+		void addSSBOAttribute(const std::wstring &p_name, const std::shared_ptr<OpenGL::ShaderStorageBufferObject> &p_object)
 		{
 			if (_attributes.contains(p_name) == true)
 			{
-				if (std::holds_alternative<OpenGL::ShaderStorageBufferObject>(_attributes[p_name]) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_attributes[p_name]) == false)
 				{
-					throw std::runtime_error("Attribute with name '" + spk::StringUtils::wstringToString(p_name) +
-											 "' is already set but is not an SSBO.");
+					throw std::runtime_error(
+						"Attribute with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not an SSBO.");
 				}
 
 				throw std::runtime_error("SSBO attribute with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set.");
 			}
 
-			_attributes[p_name] = std::move(p_object);
+			_attributes[p_name] = p_object;
 		}
 
 	public:
@@ -384,97 +401,103 @@ namespace spk::Lumina
 			_bufferSet.layout().addAttribute(p_index, p_type);
 		}
 
-		void addSampler(const std::wstring &p_name, const OpenGL::SamplerObject &p_object, Mode p_mode)
+		void addSampler(const std::wstring &p_name, const std::shared_ptr<OpenGL::SamplerObject> &p_object, Mode p_mode)
 		{
 			if (p_mode == Mode::Constant)
 			{
-				addSamplerConstant(p_name, std::move(p_object));
+				addSamplerConstant(p_name, p_object);
 			}
 			else
 			{
-				addSamplerAttribute(p_name, std::move(p_object));
+				addSamplerAttribute(p_name, p_object);
 			}
 		}
 
-		void addUBO(const std::wstring &p_name, const OpenGL::UniformBufferObject &p_object, Mode p_mode)
+		void addUBO(const std::wstring &p_name, const std::shared_ptr<OpenGL::UniformBufferObject> &p_object, Mode p_mode)
 		{
 			if (p_mode == Mode::Constant)
 			{
-				addUBOConstant(p_name, std::move(p_object));
+				addUBOConstant(p_name, p_object);
 			}
 			else
 			{
-				addUBOAttribute(p_name, std::move(p_object));
+				addUBOAttribute(p_name, p_object);
 			}
 		}
 
-		void addSSBO(const std::wstring &p_name, const OpenGL::ShaderStorageBufferObject &p_object, Mode p_mode)
+		void addSSBO(const std::wstring &p_name, const std::shared_ptr<OpenGL::ShaderStorageBufferObject> &p_object, Mode p_mode)
 		{
 			if (p_mode == Mode::Constant)
 			{
-				addSSBOConstant(p_name, std::move(p_object));
+				addSSBOConstant(p_name, p_object);
 			}
 			else
 			{
-				addSSBOAttribute(p_name, std::move(p_object));
+				addSSBOAttribute(p_name, p_object);
 			}
 		}
 
 		bool containSampler(const std::wstring &p_name) const
 		{
-			return (_availableObjects.contains(p_name) == true &&
-					std::holds_alternative<spk::SafePointer<OpenGL::SamplerObject>>(_availableObjects.at(p_name)) == true);
+			return (
+				_availableObjects.contains(p_name) == true &&
+				std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_availableObjects.at(p_name)) == true);
 		}
 
 		OpenGL::SamplerObject &sampler(const std::wstring &p_name)
 		{
 			if (_availableObjects.contains(p_name) == false)
 			{
-				throw std::runtime_error("Sampler with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants.");
+				throw std::runtime_error(
+					"Sampler with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants.");
 			}
-			if (std::holds_alternative<spk::SafePointer<OpenGL::SamplerObject>>(_availableObjects.at(p_name)) == false)
+			if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_availableObjects.at(p_name)) == false)
 			{
 				throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not a sampler object.");
 			}
-			return *(std::get<spk::SafePointer<OpenGL::SamplerObject>>(_availableObjects.at(p_name)));
+			return *(std::get<std::shared_ptr<OpenGL::SamplerObject>>(_availableObjects.at(p_name)));
 		}
 
 		bool containUBO(const std::wstring &p_name) const
 		{
-			return (_availableObjects.contains(p_name) == true &&
-					std::holds_alternative<spk::SafePointer<OpenGL::UniformBufferObject>>(_availableObjects.at(p_name)) == true);
+			return (
+				_availableObjects.contains(p_name) == true &&
+				std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_availableObjects.at(p_name)) == true);
 		}
 
 		OpenGL::UniformBufferObject &UBO(const std::wstring &p_name)
 		{
 			if (_availableObjects.contains(p_name) == false)
 			{
-				throw std::runtime_error("UBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants.");
+				throw std::runtime_error(
+					"UBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants.");
 			}
-			if (std::holds_alternative<spk::SafePointer<OpenGL::UniformBufferObject>>(_availableObjects.at(p_name)) == false)
+			if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_availableObjects.at(p_name)) == false)
 			{
 				throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not a UBO.");
 			}
-			return *(std::get<spk::SafePointer<OpenGL::UniformBufferObject>>(_availableObjects.at(p_name)));
+			return *(std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(_availableObjects.at(p_name)));
 		}
 
 		bool containSSBO(const std::wstring &p_name) const
 		{
-			return (_availableObjects.contains(p_name) == true &&
-					std::holds_alternative<spk::SafePointer<OpenGL::ShaderStorageBufferObject>>(_availableObjects.at(p_name)) == true);
+			return (
+				_availableObjects.contains(p_name) == true &&
+				std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_availableObjects.at(p_name)) == true);
 		}
 
 		OpenGL::ShaderStorageBufferObject &SSBO(const std::wstring &p_name)
 		{
 			if (_availableObjects.contains(p_name) == false)
 			{
-				throw std::runtime_error("SSBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants.");
+				throw std::runtime_error(
+					"SSBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants.");
 			}
-			if (std::holds_alternative<spk::SafePointer<OpenGL::ShaderStorageBufferObject>>(_availableObjects.at(p_name)) == false)
+			if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_availableObjects.at(p_name)) == false)
 			{
 				throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not an SSBO.");
 			}
-			return *(std::get<spk::SafePointer<OpenGL::ShaderStorageBufferObject>>(_availableObjects.at(p_name)));
+			return *(std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_availableObjects.at(p_name)));
 		}
 
 		Object createObject()
@@ -484,46 +507,49 @@ namespace spk::Lumina
 
 		struct Constants
 		{
-			static void addSampler(const std::wstring &p_name, const OpenGL::SamplerObject &p_object)
+			static void addSampler(const std::wstring &p_name, const std::shared_ptr<OpenGL::SamplerObject> &p_object)
 			{
 				if (_objects.contains(p_name) == false)
 				{
-					_objects[p_name] = std::move(p_object);
+					_objects[p_name] = p_object;
 				}
 			}
 
-			static void addUBO(const std::wstring &p_name, const OpenGL::UniformBufferObject &p_object)
+			static void addUBO(const std::wstring &p_name, const std::shared_ptr<OpenGL::UniformBufferObject> &p_object)
 			{
 				if (_objects.contains(p_name) == false)
 				{
-					_objects[p_name] = std::move(p_object);
+					_objects[p_name] = p_object;
 				}
 			}
 
-			static void addSSBO(const std::wstring &p_name, const OpenGL::ShaderStorageBufferObject &p_object)
+			static void addSSBO(const std::wstring &p_name, const std::shared_ptr<OpenGL::ShaderStorageBufferObject> &p_object)
 			{
 				if (_objects.contains(p_name) == false)
 				{
-					_objects[p_name] = std::move(p_object);
+					_objects[p_name] = p_object;
 				}
 			}
 
 			static bool containsSampler(const std::wstring &p_name)
 			{
-				return (Shader::_objects.contains(p_name) == true &&
-						std::holds_alternative<OpenGL::SamplerObject>(Shader::_objects.at(p_name)) == true);
+				return (
+					Shader::_objects.contains(p_name) == true &&
+					std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(Shader::_objects.at(p_name)) == true);
 			}
 
 			static bool containsUBO(const std::wstring &p_name)
 			{
-				return (Shader::_objects.contains(p_name) == true &&
-						std::holds_alternative<OpenGL::UniformBufferObject>(Shader::_objects.at(p_name)) == true);
+				return (
+					Shader::_objects.contains(p_name) == true &&
+					std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(Shader::_objects.at(p_name)) == true);
 			}
 
 			static bool containsSSBO(const std::wstring &p_name)
 			{
-				return (Shader::_objects.contains(p_name) == true &&
-						std::holds_alternative<OpenGL::ShaderStorageBufferObject>(Shader::_objects.at(p_name)) == true);
+				return (
+					Shader::_objects.contains(p_name) == true &&
+					std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(Shader::_objects.at(p_name)) == true);
 			}
 
 			static OpenGL::SamplerObject &sampler(const std::wstring &p_name)
@@ -532,11 +558,11 @@ namespace spk::Lumina
 				{
 					throw std::runtime_error("Sampler with name '" + spk::StringUtils::wstringToString(p_name) + "' not found.");
 				}
-				if (std::holds_alternative<OpenGL::SamplerObject>(Shader::_objects[p_name]) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(Shader::_objects[p_name]) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not an Sampler.");
 				}
-				return (std::get<OpenGL::SamplerObject>(Shader::_objects[p_name]));
+				return *(std::get<std::shared_ptr<OpenGL::SamplerObject>>(Shader::_objects[p_name]));
 			}
 
 			static OpenGL::UniformBufferObject &ubo(const std::wstring &p_name)
@@ -545,11 +571,11 @@ namespace spk::Lumina
 				{
 					throw std::runtime_error("UBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found.");
 				}
-				if (std::holds_alternative<OpenGL::UniformBufferObject>(Shader::_objects[p_name]) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(Shader::_objects[p_name]) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not an UBO.");
 				}
-				return (std::get<OpenGL::UniformBufferObject>(Shader::_objects[p_name]));
+				return *(std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(Shader::_objects[p_name]));
 			}
 
 			static OpenGL::ShaderStorageBufferObject &ssbo(const std::wstring &p_name)
@@ -558,11 +584,11 @@ namespace spk::Lumina
 				{
 					throw std::runtime_error("SSBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found.");
 				}
-				if (std::holds_alternative<OpenGL::ShaderStorageBufferObject>(Shader::_objects[p_name]) == false)
+				if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(Shader::_objects[p_name]) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not an SSBO.");
 				}
-				return (std::get<OpenGL::ShaderStorageBufferObject>(Shader::_objects[p_name]));
+				return *(std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(Shader::_objects[p_name]));
 			}
 		};
 	};

--- a/include/structure/graphics/lumina/spk_shader_object_factory.hpp
+++ b/include/structure/graphics/lumina/spk_shader_object_factory.hpp
@@ -6,6 +6,7 @@
 #include "structure/graphics/opengl/spk_shader_storage_buffer_object.hpp"
 #include "structure/graphics/opengl/spk_uniform_buffer_object.hpp"
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <variant>
@@ -17,7 +18,10 @@ namespace spk::Lumina
 	private:
 		friend class spk::Singleton<ShaderObjectFactory>;
 
-		using Object = std::variant<OpenGL::UniformBufferObject, OpenGL::ShaderStorageBufferObject, OpenGL::SamplerObject>;
+		using Object = std::variant<
+			std::shared_ptr<OpenGL::UniformBufferObject>,
+			std::shared_ptr<OpenGL::ShaderStorageBufferObject>,
+			std::shared_ptr<OpenGL::SamplerObject>>;
 
 		std::unordered_map<std::wstring, Object> _objects;
 
@@ -30,8 +34,8 @@ namespace spk::Lumina
 	public:
 		void add(const spk::JSON::Object &p_desc);
 
-		OpenGL::UniformBufferObject &ubo(const std::wstring &p_name);
-		OpenGL::ShaderStorageBufferObject &ssbo(const std::wstring &p_name);
-		OpenGL::SamplerObject &sampler(const std::wstring &p_name);
+		std::shared_ptr<OpenGL::UniformBufferObject> ubo(const std::wstring &p_name);
+		std::shared_ptr<OpenGL::ShaderStorageBufferObject> ssbo(const std::wstring &p_name);
+		std::shared_ptr<OpenGL::SamplerObject> sampler(const std::wstring &p_name);
 	};
 }

--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -14,7 +14,7 @@ class Shape : public spk::Entity
 public:
 	enum class Type
 	{
-		Triangle, 
+		Triangle,
 		Square,
 		Pentagon,
 		Hexagon,
@@ -34,7 +34,7 @@ private:
 	using InfoContainer = std::list<Info>;
 	using InfoIterator = InfoContainer::iterator;
 
-	static ShapeMesh _makeMesh(const Shape::Type& p_type)
+	static ShapeMesh _makeMesh(const Shape::Type &p_type)
 	{
 		static const std::unordered_map<Shape::Type, size_t> nbPointCount = {
 			{Shape::Type::Triangle, 3},
@@ -42,10 +42,9 @@ private:
 			{Shape::Type::Pentagon, 5},
 			{Shape::Type::Hexagon, 6},
 			{Shape::Type::Octogon, 8},
-			{Shape::Type::Circle, 30}
-		};
+			{Shape::Type::Circle, 30}};
 		ShapeMesh result;
-		
+
 		std::vector<spk::Vector2> vertices;
 		size_t nbPoint = nbPointCount.at(p_type);
 		const float step = (2.0f * M_PI) / static_cast<float>(nbPoint);
@@ -139,12 +138,12 @@ void main()
 				spk::Lumina::Shader shader(vertexShaderSrc, fragmentShaderSrc);
 
 				shader.addAttribute({0, spk::OpenGL::LayoutBufferObject::Attribute::Type::Vector2});
-				
+
 				shader.addUBO(L"CameraUBO", spk::Lumina::ShaderObjectFactory::instance()->ubo(L"CameraUBO"), spk::Lumina::Shader::Mode::Constant);
 
-				spk::OpenGL::ShaderStorageBufferObject infoSSBO = spk::OpenGL::ShaderStorageBufferObject(L"InfoSSBO", 1, 0, 0, 80, 0);
-				infoSSBO.dynamicArray().addElement(L"model", 0, 64);
-				infoSSBO.dynamicArray().addElement(L"color", 64, 16);
+				auto infoSSBO = std::make_shared<spk::OpenGL::ShaderStorageBufferObject>(L"InfoSSBO", 1, 0, 0, 80, 0);
+				infoSSBO->dynamicArray().addElement(L"model", 0, 64);
+				infoSSBO->dynamicArray().addElement(L"color", 64, 16);
 
 				shader.addSSBO(L"InfoSSBO", infoSSBO, spk::Lumina::Shader::Mode::Attribute);
 
@@ -153,12 +152,12 @@ void main()
 			static inline spk::Lumina::Shader _shader = _createShader();
 
 			spk::Lumina::Shader::Object _object;
-			spk::OpenGL::BufferSet& _bufferSet;
+			spk::OpenGL::BufferSet &_bufferSet;
 			spk::OpenGL::ShaderStorageBufferObject &_infoSSBO;
 
 			spk::SafePointer<const InfoContainer> _infoContainer;
 
-			void _prepare(const ShapeMesh& p_mesh)
+			void _prepare(const ShapeMesh &p_mesh)
 			{
 				const auto &buffer = p_mesh.buffer();
 
@@ -180,7 +179,7 @@ void main()
 			{
 				_prepare(p_mesh);
 			}
-			
+
 			void render()
 			{
 				size_t nbInstance = _infoSSBO.dynamicArray().nbElement();
@@ -193,7 +192,7 @@ void main()
 			{
 				_infoContainer = p_infoContainer;
 			}
-			
+
 			void validate()
 			{
 				if (_infoContainer == nullptr)
@@ -202,7 +201,7 @@ void main()
 				}
 
 				auto &array = _infoSSBO.dynamicArray();
-				
+
 				array.resize(_infoContainer->size());
 
 				size_t index = 0;
@@ -222,8 +221,7 @@ void main()
 			{Shape::Type::Pentagon, Painter(_makeMesh(Shape::Type::Pentagon))},
 			{Shape::Type::Hexagon, Painter(_makeMesh(Shape::Type::Hexagon))},
 			{Shape::Type::Octogon, Painter(_makeMesh(Shape::Type::Octogon))},
-			{Shape::Type::Circle, Painter(_makeMesh(Shape::Type::Circle))}
-		};
+			{Shape::Type::Circle, Painter(_makeMesh(Shape::Type::Circle))}};
 
 		struct ContainerData
 		{
@@ -243,11 +241,10 @@ void main()
 			{Shape::Type::Pentagon, ContainerData()},
 			{Shape::Type::Hexagon, ContainerData()},
 			{Shape::Type::Octogon, ContainerData()},
-			{Shape::Type::Circle, ContainerData()}
-		};
+			{Shape::Type::Circle, ContainerData()}};
 
 	public:
-		Renderer(const std::wstring& p_name) :
+		Renderer(const std::wstring &p_name) :
 			spk::Component(p_name)
 		{
 			for (auto &painter : painters)
@@ -256,12 +253,12 @@ void main()
 			}
 		}
 
-		void onPaintEvent(spk::PaintEvent& p_event) override
+		void onPaintEvent(spk::PaintEvent &p_event) override
 		{
-			for (auto& painter : painters)
+			for (auto &painter : painters)
 			{
 				if (containers[painter.first].container.empty() == false)
-				{	
+				{
 					if (containers[painter.first].needUpdate == true)
 					{
 						painter.second.validate();
@@ -272,25 +269,25 @@ void main()
 			}
 		}
 
-		static InfoIterator subscribe(const Shape::Type& p_type)
+		static InfoIterator subscribe(const Shape::Type &p_type)
 		{
-			auto& data = containers[p_type];
+			auto &data = containers[p_type];
 
 			data.needUpdate = true;
 
 			return data.container.emplace(data.container.end(), Info{});
 		}
 
-		static void remove(const Shape::Type& p_type, const InfoIterator& p_iterator)
+		static void remove(const Shape::Type &p_type, const InfoIterator &p_iterator)
 		{
-			auto& data = containers[p_type];
+			auto &data = containers[p_type];
 
 			data.container.erase(p_iterator);
 
-		    data.needUpdate = true;
+			data.needUpdate = true;
 		}
 
-		static void validate(const Shape::Type& p_type)
+		static void validate(const Shape::Type &p_type)
 		{
 			containers[p_type].needUpdate = true;
 		}
@@ -308,7 +305,7 @@ private:
 		{
 			if (_type.has_value() == false)
 			{
-				return ;
+				return;
 			}
 			_iterator = Renderer::subscribe(_type.value());
 		}
@@ -323,13 +320,13 @@ private:
 		}
 
 	public:
-		Subscriber(const std::wstring& p_name) : 
+		Subscriber(const std::wstring &p_name) :
 			spk::Component(p_name)
 		{
 			_type.reset();
 		}
 
-		void setType(const Shape::Type& p_type)
+		void setType(const Shape::Type &p_type)
 		{
 			if (_type.has_value() == true)
 			{
@@ -343,15 +340,17 @@ private:
 
 		void start() override
 		{
-			_onEditionContract = owner()->transform().addOnEditionCallback([&](){
-				if (_type.has_value() == false)
+			_onEditionContract = owner()->transform().addOnEditionCallback(
+				[&]()
 				{
-					GENERATE_ERROR("Can't use an Shape without type");
-				}
+					if (_type.has_value() == false)
+					{
+						GENERATE_ERROR("Can't use an Shape without type");
+					}
 
-				_iterator->model = owner()->transform().model();
-				Renderer::validate(_type.value());
-			});
+					_iterator->model = owner()->transform().model();
+					Renderer::validate(_type.value());
+				});
 		}
 
 		void awake() override
@@ -369,13 +368,13 @@ private:
 	spk::SafePointer<Subscriber> _subscriber;
 
 public:
-	Shape(const std::wstring& p_name, spk::SafePointer<spk::Entity> p_parent) : 
+	Shape(const std::wstring &p_name, spk::SafePointer<spk::Entity> p_parent) :
 		spk::Entity(p_name, p_parent),
 		_subscriber(addComponent<Subscriber>(p_name + L"/Subscriber"))
 	{
 	}
 
-	void setType(const Type& p_type)
+	void setType(const Type &p_type)
 	{
 		_subscriber->setType(p_type);
 	}
@@ -630,7 +629,7 @@ private:
 	spk::SafePointer<spk::CameraComponent> _cameraComponent;
 
 public:
-	CameraHolder(const std::wstring& p_name, spk::SafePointer<spk::Entity> p_parent) :
+	CameraHolder(const std::wstring &p_name, spk::SafePointer<spk::Entity> p_parent) :
 		spk::Entity(p_name, p_parent),
 		_cameraComponent(addComponent<spk::CameraComponent>(L"Camera/CameraComponent"))
 	{
@@ -656,12 +655,11 @@ private:
 	spk::SafePointer<TopDown2DController> _controller;
 
 public:
-	Player(const std::wstring& p_name, spk::SafePointer<spk::Entity> p_parent) :
+	Player(const std::wstring &p_name, spk::SafePointer<spk::Entity> p_parent) :
 		Shape(p_name, p_parent),
 		_cameraHolder(CameraHolder(p_name + L"/CameraHolder", this)),
 		_controller(addComponent<TopDown2DController>(p_name + L"/Controller"))
 	{
-
 	}
 
 	spk::SafePointer<const CameraHolder> camera() const
@@ -793,9 +791,12 @@ int main()
 	tileMap.activate();
 	tileMap.setSpriteSheet(&tilemapSpriteSheet);
 	tileMap.addTileByID(0, PlaygroundTileMap::TileType({0, 0}, PlaygroundTileMap::TileType::Type::Autotile, TileFlag::Obstacle)); // Wall
-	tileMap.addTileByID(1, PlaygroundTileMap::TileType({4, 0}, PlaygroundTileMap::TileType::Type::Autotile, TileFlag::TerritoryBlue)); // Blue territory
-	tileMap.addTileByID(2, PlaygroundTileMap::TileType({8, 0}, PlaygroundTileMap::TileType::Type::Autotile, TileFlag::TerritoryGreen)); // Green territory
-	tileMap.addTileByID(3, PlaygroundTileMap::TileType({12, 0}, PlaygroundTileMap::TileType::Type::Autotile, TileFlag::TerritoryRed)); // Red territory
+	tileMap.addTileByID(
+		1, PlaygroundTileMap::TileType({4, 0}, PlaygroundTileMap::TileType::Type::Autotile, TileFlag::TerritoryBlue)); // Blue territory
+	tileMap.addTileByID(
+		2, PlaygroundTileMap::TileType({8, 0}, PlaygroundTileMap::TileType::Type::Autotile, TileFlag::TerritoryGreen)); // Green territory
+	tileMap.addTileByID(
+		3, PlaygroundTileMap::TileType({12, 0}, PlaygroundTileMap::TileType::Type::Autotile, TileFlag::TerritoryRed)); // Red territory
 	// ------------------------------------------
 
 	// ------------- Player entity --------------

--- a/src/structure/graphics/lumina/spk_shader_object_factory.cpp
+++ b/src/structure/graphics/lumina/spk_shader_object_factory.cpp
@@ -27,19 +27,19 @@ namespace spk::Lumina
 			const JSON::Object &desc = p_ubos[index];
 			std::wstring name = desc[L"name"].as<std::wstring>();
 			const JSON::Object &data = desc[L"data"];
-			OpenGL::UniformBufferObject newUBO(data);
+			auto newUBO = std::make_shared<OpenGL::UniformBufferObject>(data);
 
 			if (_objects.contains(name))
 			{
-				auto &existing = std::get<OpenGL::UniformBufferObject>(_objects[name]);
-				if (existing.size() != newUBO.size())
+				auto existing = std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(_objects[name]);
+				if (existing->size() != newUBO->size())
 				{
 					GENERATE_ERROR("UBO '" + StringUtils::wstringToString(name) + "' already exists with a different size.");
 				}
 			}
 			else
 			{
-				_objects[name] = std::move(newUBO);
+				_objects[name] = newUBO;
 			}
 		}
 	}
@@ -51,20 +51,20 @@ namespace spk::Lumina
 			const spk::JSON::Object &desc = p_ssbos[index];
 			std::wstring name = desc[L"name"].as<std::wstring>();
 			const spk::JSON::Object &data = desc[L"data"];
-			spk::OpenGL::ShaderStorageBufferObject newSSBO(data);
+			auto newSSBO = std::make_shared<spk::OpenGL::ShaderStorageBufferObject>(data);
 
 			if (_objects.contains(name))
 			{
-				auto &existing = std::get<spk::OpenGL::ShaderStorageBufferObject>(_objects[name]);
-				if (existing.fixedData().size() != newSSBO.fixedData().size() ||
-					existing.dynamicArray().elementSize() != newSSBO.dynamicArray().elementSize())
+				auto existing = std::get<std::shared_ptr<spk::OpenGL::ShaderStorageBufferObject>>(_objects[name]);
+				if (existing->fixedData().size() != newSSBO->fixedData().size() ||
+					existing->dynamicArray().elementSize() != newSSBO->dynamicArray().elementSize())
 				{
 					GENERATE_ERROR("SSBO '" + spk::StringUtils::wstringToString(name) + "' already exists with a different size.");
 				}
 			}
 			else
 			{
-				_objects[name] = std::move(newSSBO);
+				_objects[name] = newSSBO;
 			}
 		}
 	}
@@ -76,12 +76,12 @@ namespace spk::Lumina
 			const spk::JSON::Object &desc = p_samplers[index];
 			std::wstring alias = desc[L"name"].as<std::wstring>();
 			const spk::JSON::Object &data = desc[L"data"];
-			spk::OpenGL::SamplerObject newSampler(data);
+			auto newSampler = std::make_shared<spk::OpenGL::SamplerObject>(data);
 
 			if (_objects.contains(alias))
 			{
-				auto &existing = std::get<spk::OpenGL::SamplerObject>(_objects[alias]);
-				if (existing.bindingPoint() != newSampler.bindingPoint() || existing.type() != newSampler.type())
+				auto existing = std::get<std::shared_ptr<spk::OpenGL::SamplerObject>>(_objects[alias]);
+				if (existing->bindingPoint() != newSampler->bindingPoint() || existing->type() != newSampler->type())
 				{
 					GENERATE_ERROR(
 						"Sampler '" + spk::StringUtils::wstringToString(alias) + "' already exists with a different binding point or type.");
@@ -89,23 +89,23 @@ namespace spk::Lumina
 			}
 			else
 			{
-				_objects[alias] = std::move(newSampler);
+				_objects[alias] = newSampler;
 			}
 		}
 	}
 
-	spk::OpenGL::UniformBufferObject &ShaderObjectFactory::ubo(const std::wstring &p_name)
+	std::shared_ptr<spk::OpenGL::UniformBufferObject> ShaderObjectFactory::ubo(const std::wstring &p_name)
 	{
-		return (std::get<spk::OpenGL::UniformBufferObject>(_objects.at(p_name)));
+		return (std::get<std::shared_ptr<spk::OpenGL::UniformBufferObject>>(_objects.at(p_name)));
 	}
 
-	spk::OpenGL::ShaderStorageBufferObject &ShaderObjectFactory::ssbo(const std::wstring &p_name)
+	std::shared_ptr<spk::OpenGL::ShaderStorageBufferObject> ShaderObjectFactory::ssbo(const std::wstring &p_name)
 	{
-		return (std::get<spk::OpenGL::ShaderStorageBufferObject>(_objects.at(p_name)));
+		return (std::get<std::shared_ptr<spk::OpenGL::ShaderStorageBufferObject>>(_objects.at(p_name)));
 	}
 
-	spk::OpenGL::SamplerObject &ShaderObjectFactory::sampler(const std::wstring &p_name)
+	std::shared_ptr<spk::OpenGL::SamplerObject> ShaderObjectFactory::sampler(const std::wstring &p_name)
 	{
-		return (std::get<spk::OpenGL::SamplerObject>(_objects.at(p_name)));
+		return (std::get<std::shared_ptr<spk::OpenGL::SamplerObject>>(_objects.at(p_name)));
 	}
 }


### PR DESCRIPTION
## Summary
- manage shader constants and attributes via `std::shared_ptr` to avoid invalidating external resources
- return shared pointers from `ShaderObjectFactory` and adapt shader `add*` APIs
- store shader attributes as shared pointers instead of raw objects
- rename shared resource variant alias to `Unit` for clarity

## Testing
- `clang-format -i include/structure/graphics/lumina/spk_shader.hpp`
- `clang-tidy include/structure/graphics/lumina/spk_shader.hpp -- -std=c++20 -Iinclude` *(fails: 'GL/glew.h' file not found; multiple naming warnings)*
- `cmake --preset test-debug` *(fails: Could not find toolchain file: /scripts/buildsystems/vcpkg.cmake; CMAKE_MAKE_PROGRAM is not set)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bea3542f308325ada8b6037c2fa48d