### PR TITLE
Refactor static members to lazy functions

### DIFF
--- a/include/application/module/spk_module.hpp
+++ b/include/application/module/spk_module.hpp
@@ -35,7 +35,7 @@ namespace spk
 
 		const std::vector<UINT> &eventIDs() override
 		{
-			return (TEventType::EventIDs);
+			return (TEventType::eventIDs());
 		}
 
 		void receiveEvent(spk::Event &&p_event) override

--- a/include/structure/engine/spk_collider.hpp
+++ b/include/structure/engine/spk_collider.hpp
@@ -29,8 +29,16 @@ namespace spk
 		spk::BoundingBox _boundingBox;
 		std::vector<spk::Polygon> _polygons;
 		Mode _mode = Mode::Blocking;
-		static inline std::vector<spk::SafePointer<Collider>> _colliders;
-		static inline std::mutex _collidersMutex;
+		static std::vector<spk::SafePointer<Collider>> &_colliders()
+		{
+			static std::vector<spk::SafePointer<Collider>> colliders;
+			return colliders;
+		}
+		static std::mutex &_collidersMutex()
+		{
+			static std::mutex collidersMutex;
+			return collidersMutex;
+		}
 		spk::TContractProvider<spk::SafePointer<spk::Entity>> _onCollisionEnterProvider;
 
 		std::vector<spk::SafePointer<const Collider>> _executeCollisionTest();

--- a/include/structure/engine/spk_collider_2d.hpp
+++ b/include/structure/engine/spk_collider_2d.hpp
@@ -29,8 +29,16 @@ namespace spk
 		spk::BoundingBox2D _boundingBox;
 		std::vector<spk::Polygon2D> _polygons;
 		Mode _mode = Mode::Blocking;
-		static inline std::vector<spk::SafePointer<Collider2D>> _colliders;
-		static inline std::mutex _collidersMutex;
+		static std::vector<spk::SafePointer<Collider2D>> &_colliders()
+		{
+			static std::vector<spk::SafePointer<Collider2D>> colliders;
+			return colliders;
+		}
+		static std::mutex &_collidersMutex()
+		{
+			static std::mutex collidersMutex;
+			return collidersMutex;
+		}
 		spk::TContractProvider<spk::SafePointer<spk::Entity>> _onCollisionEnterProvider;
 
 		std::vector<spk::SafePointer<const Collider2D>> _executeCollisionTest();

--- a/include/structure/engine/spk_collision_mesh_2d_renderer.hpp
+++ b/include/structure/engine/spk_collision_mesh_2d_renderer.hpp
@@ -14,7 +14,11 @@ namespace spk
 		class Painter
 		{
 		private:
-			static inline spk::Lumina::ShaderObjectFactory::Instanciator _instanciator;
+			static spk::Lumina::ShaderObjectFactory::Instanciator &_instanciator()
+			{
+				static spk::Lumina::ShaderObjectFactory::Instanciator instanciator;
+				return instanciator;
+			}
 
 			static spk::Lumina::Shader _createShader();
 			static spk::Lumina::Shader _shader;

--- a/include/structure/engine/spk_collision_mesh_renderer.hpp
+++ b/include/structure/engine/spk_collision_mesh_renderer.hpp
@@ -14,7 +14,11 @@ namespace spk
 		class Painter
 		{
 		private:
-			static inline spk::Lumina::ShaderObjectFactory::Instanciator _instanciator;
+			static spk::Lumina::ShaderObjectFactory::Instanciator &_instanciator()
+			{
+				static spk::Lumina::ShaderObjectFactory::Instanciator instanciator;
+				return instanciator;
+			}
 
 			static spk::Lumina::Shader _createShader();
 			static spk::Lumina::Shader _shader;

--- a/include/structure/engine/spk_color_mesh_renderer.hpp
+++ b/include/structure/engine/spk_color_mesh_renderer.hpp
@@ -14,7 +14,11 @@ namespace spk
 		class Painter
 		{
 		private:
-			static inline spk::Lumina::ShaderObjectFactory::Instanciator _instanciator;
+			static spk::Lumina::ShaderObjectFactory::Instanciator &_instanciator()
+			{
+				static spk::Lumina::ShaderObjectFactory::Instanciator instanciator;
+				return instanciator;
+			}
 
 			static spk::Lumina::Shader _createShader();
 			static spk::Lumina::Shader _shader;

--- a/include/structure/engine/spk_mesh_2d_renderer.hpp
+++ b/include/structure/engine/spk_mesh_2d_renderer.hpp
@@ -15,7 +15,11 @@ namespace spk
 		class Painter
 		{
 		private:
-			static inline spk::Lumina::ShaderObjectFactory::Instanciator _instanciator;
+			static spk::Lumina::ShaderObjectFactory::Instanciator &_instanciator()
+			{
+				static spk::Lumina::ShaderObjectFactory::Instanciator instanciator;
+				return instanciator;
+			}
 
 			static spk::Lumina::Shader _createShader();
 			static spk::Lumina::Shader _shader;

--- a/include/structure/engine/spk_obj_mesh.hpp
+++ b/include/structure/engine/spk_obj_mesh.hpp
@@ -16,7 +16,11 @@ namespace spk
 	class ObjMesh : public TMesh<ObjVertex>
 	{
 	private:
-		static inline std::unordered_map<std::filesystem::path, spk::Texture> _materials;
+		static std::unordered_map<std::filesystem::path, spk::Texture> &_materials()
+		{
+			static std::unordered_map<std::filesystem::path, spk::Texture> materials;
+			return materials;
+		}
 		std::filesystem::path _materialPath;
 		mutable spk::TContractProvider<spk::SafePointer<spk::Texture>> _onMaterialChangeProvider;
 

--- a/include/structure/engine/spk_obj_mesh_renderer.hpp
+++ b/include/structure/engine/spk_obj_mesh_renderer.hpp
@@ -15,7 +15,11 @@ namespace spk
 		class Painter
 		{
 		private:
-			static inline spk::Lumina::ShaderObjectFactory::Instanciator _instanciator;
+			static spk::Lumina::ShaderObjectFactory::Instanciator &_instanciator()
+			{
+				static spk::Lumina::ShaderObjectFactory::Instanciator instanciator;
+				return instanciator;
+			}
 
 			static spk::Lumina::Shader _createShader();
 			static spk::Lumina::Shader _shader;

--- a/include/structure/graphics/opengl/spk_texture_collection.hpp
+++ b/include/structure/graphics/opengl/spk_texture_collection.hpp
@@ -22,8 +22,16 @@ namespace spk::OpenGL
 			std::unique_ptr<spk::OpenGL::TextureObject> gpuPtr;
 		};
 
-		static inline std::unordered_map<spk::Texture::ID, TexturePair> _cpuToGpuMap;
-		static inline std::unordered_map<GLuint, spk::Texture::ID> _gpuToCpuMap;
+		static std::unordered_map<spk::Texture::ID, TexturePair> &_cpuToGpuMap()
+		{
+			static std::unordered_map<spk::Texture::ID, TexturePair> cpuToGpuMap;
+			return cpuToGpuMap;
+		}
+		static std::unordered_map<GLuint, spk::Texture::ID> &_gpuToCpuMap()
+		{
+			static std::unordered_map<GLuint, spk::Texture::ID> gpuToCpuMap;
+			return gpuToCpuMap;
+		}
 
 	public:
 		static spk::SafePointer<spk::OpenGL::TextureObject> textureObject(
@@ -35,9 +43,9 @@ namespace spk::OpenGL
 			}
 
 			spk::Texture::ID cpuID = p_cpuTexture->_id;
-			auto it = _cpuToGpuMap.find(cpuID);
+			auto it = _cpuToGpuMap().find(cpuID);
 
-			if (it != _cpuToGpuMap.end())
+			if (it != _cpuToGpuMap().end())
 			{
 				return it->second.gpuPtr.get();
 			}
@@ -50,10 +58,10 @@ namespace spk::OpenGL
 			pair.cpuPtr = p_cpuTexture;
 			pair.gpuPtr = std::move(newGPU);
 
-			_cpuToGpuMap.insert({cpuID, std::move(pair)});
-			_gpuToCpuMap.insert({gpuID, cpuID});
+			_cpuToGpuMap().insert({cpuID, std::move(pair)});
+			_gpuToCpuMap().insert({gpuID, cpuID});
 
-			return _cpuToGpuMap[cpuID].gpuPtr.get();
+			return _cpuToGpuMap()[cpuID].gpuPtr.get();
 		}
 
 		static spk::SafePointer<const spk::Texture> texture(const spk::OpenGL::TextureObject *p_gpuTexture)
@@ -64,15 +72,15 @@ namespace spk::OpenGL
 			}
 
 			GLuint gpuID = p_gpuTexture->id();
-			auto it = _gpuToCpuMap.find(gpuID);
-			if (it == _gpuToCpuMap.end())
+			auto it = _gpuToCpuMap().find(gpuID);
+			if (it == _gpuToCpuMap().end())
 			{
 				return nullptr;
 			}
 
 			spk::Texture::ID cpuID = it->second;
-			auto jt = _cpuToGpuMap.find(cpuID);
-			if (jt == _cpuToGpuMap.end())
+			auto jt = _cpuToGpuMap().find(cpuID);
+			if (jt == _cpuToGpuMap().end())
 			{
 				return nullptr;
 			}

--- a/include/structure/graphics/painter/spk_color_painter.hpp
+++ b/include/structure/graphics/painter/spk_color_painter.hpp
@@ -20,7 +20,11 @@ namespace spk
 		};
 
 	private:
-		static inline std::unique_ptr<spk::OpenGL::Program> _program = nullptr;
+		static std::unique_ptr<spk::OpenGL::Program> &_program()
+		{
+			static std::unique_ptr<spk::OpenGL::Program> program = nullptr;
+			return program;
+		}
 		spk::OpenGL::BufferSet _bufferSet;
 		spk::OpenGL::UniformBufferObject _colorUniformBufferObject;
 

--- a/include/structure/graphics/painter/spk_font_painter.hpp
+++ b/include/structure/graphics/painter/spk_font_painter.hpp
@@ -30,7 +30,11 @@ namespace spk
 		};
 
 	private:
-		static inline std::unique_ptr<spk::OpenGL::Program> _program;
+		static std::unique_ptr<spk::OpenGL::Program> &_program()
+		{
+			static std::unique_ptr<spk::OpenGL::Program> program;
+			return program;
+		}
 		spk::OpenGL::BufferSet _bufferSet;
 		spk::OpenGL::SamplerObject _samplerObject;
 

--- a/include/structure/graphics/painter/spk_texture_painter.hpp
+++ b/include/structure/graphics/painter/spk_texture_painter.hpp
@@ -19,7 +19,11 @@ namespace spk
 			spk::Vector2 uv;
 		};
 
-		static inline std::unique_ptr<spk::OpenGL::Program> _program = nullptr;
+		static std::unique_ptr<spk::OpenGL::Program> &_program()
+		{
+			static std::unique_ptr<spk::OpenGL::Program> program = nullptr;
+			return program;
+		}
 		spk::OpenGL::BufferSet _bufferSet;
 		spk::OpenGL::SamplerObject _samplerObject;
 

--- a/include/structure/graphics/texture/spk_font.hpp
+++ b/include/structure/graphics/texture/spk_font.hpp
@@ -29,7 +29,11 @@ namespace spk
 			Vector2Int step;
 			Vector2Int baselineOffset;
 			Vector2UInt size;
-			static inline std::vector<unsigned int> indexesOrder = {0, 1, 2, 2, 1, 3};
+			static const std::vector<unsigned int> &indexesOrder()
+			{
+				static const std::vector<unsigned int> order = {0, 1, 2, 2, 1, 3};
+				return order;
+			}
 
 			void rescale(const Vector2 &p_scaleRatio);
 		};

--- a/include/structure/graphics/texture/spk_texture.hpp
+++ b/include/structure/graphics/texture/spk_texture.hpp
@@ -85,7 +85,11 @@ namespace spk
 		};
 
 	private:
-		static inline std::deque<ID> _availableIDs;
+		static std::deque<ID> &_availableIDs()
+		{
+			static std::deque<ID> ids;
+			return ids;
+		}
 		static inline ID _nextID = 0;
 		static inline ID InvalidID = -1;
 

--- a/include/structure/spk_iostream.hpp
+++ b/include/structure/spk_iostream.hpp
@@ -12,7 +12,11 @@ namespace spk
 		std::wstring _prefix;
 		std::wstringstream _buffer;
 		std::wostream *_outputStream = nullptr;
-		static inline std::recursive_mutex _mutex;
+		static std::recursive_mutex &_mutex()
+		{
+			static std::recursive_mutex mutex;
+			return mutex;
+		}
 
 		void _flushBuffer();
 

--- a/include/structure/system/event/spk_event.hpp
+++ b/include/structure/system/event/spk_event.hpp
@@ -62,7 +62,11 @@ namespace spk
 
 	struct PaintEvent : public IEvent
 	{
-		static inline std::vector<UINT> EventIDs = {WM_PAINT_REQUEST, WM_RESIZE_REQUEST};
+		static const std::vector<UINT> &eventIDs()
+		{
+			static const std::vector<UINT> eventIds = {WM_PAINT_REQUEST, WM_RESIZE_REQUEST};
+			return eventIds;
+		}
 		enum class Type
 		{
 			Unknow,
@@ -75,7 +79,11 @@ namespace spk
 
 	struct UpdateEvent : public IEvent
 	{
-		static inline std::vector<UINT> EventIDs = {WM_UPDATE_REQUEST};
+		static const std::vector<UINT> &eventIDs()
+		{
+			static const std::vector<UINT> eventIds = {WM_UPDATE_REQUEST};
+			return eventIds;
+		}
 		enum class Type
 		{
 			Unknow,
@@ -92,18 +100,22 @@ namespace spk
 
 	struct MouseEvent : public IEvent
 	{
-		static inline std::vector<UINT> EventIDs = {
-			WM_LBUTTONDOWN,
-			WM_RBUTTONDOWN,
-			WM_MBUTTONDOWN,
-			WM_LBUTTONUP,
-			WM_RBUTTONUP,
-			WM_MBUTTONUP,
-			WM_LBUTTONDBLCLK,
-			WM_RBUTTONDBLCLK,
-			WM_MBUTTONDBLCLK,
-			WM_MOUSEMOVE,
-			WM_MOUSEWHEEL};
+		static const std::vector<UINT> &eventIDs()
+		{
+			static const std::vector<UINT> eventIds = {
+				WM_LBUTTONDOWN,
+				WM_RBUTTONDOWN,
+				WM_MBUTTONDOWN,
+				WM_LBUTTONUP,
+				WM_RBUTTONUP,
+				WM_MBUTTONUP,
+				WM_LBUTTONDBLCLK,
+				WM_RBUTTONDBLCLK,
+				WM_MBUTTONDBLCLK,
+				WM_MOUSEMOVE,
+				WM_MOUSEWHEEL};
+			return eventIds;
+		}
 		enum class Type
 		{
 			Unknow,
@@ -124,7 +136,11 @@ namespace spk
 
 	struct KeyboardEvent : public IEvent
 	{
-		static inline std::vector<UINT> EventIDs = {WM_KEYDOWN, WM_KEYUP, WM_CHAR};
+		static const std::vector<UINT> &eventIDs()
+		{
+			static const std::vector<UINT> eventIds = {WM_KEYDOWN, WM_KEYUP, WM_CHAR};
+			return eventIds;
+		}
 		enum class Type
 		{
 			Unknow,
@@ -143,19 +159,23 @@ namespace spk
 
 	struct ControllerEvent : public IEvent
 	{
-		static inline std::vector<UINT> EventIDs = {
-			WM_LEFT_JOYSTICK_MOTION,
-			WM_RIGHT_JOYSTICK_MOTION,
-			WM_LEFT_JOYSTICK_RESET,
-			WM_RIGHT_JOYSTICK_RESET,
-			WM_LEFT_TRIGGER_MOTION,
-			WM_RIGHT_TRIGGER_MOTION,
-			WM_LEFT_TRIGGER_RESET,
-			WM_RIGHT_TRIGGER_RESET,
-			WM_DIRECTIONAL_CROSS_MOTION,
-			WM_DIRECTIONAL_CROSS_RESET,
-			WM_CONTROLLER_BUTTON_PRESS,
-			WM_CONTROLLER_BUTTON_RELEASE};
+		static const std::vector<UINT> &eventIDs()
+		{
+			static const std::vector<UINT> eventIds = {
+				WM_LEFT_JOYSTICK_MOTION,
+				WM_RIGHT_JOYSTICK_MOTION,
+				WM_LEFT_JOYSTICK_RESET,
+				WM_RIGHT_JOYSTICK_RESET,
+				WM_LEFT_TRIGGER_MOTION,
+				WM_RIGHT_TRIGGER_MOTION,
+				WM_LEFT_TRIGGER_RESET,
+				WM_RIGHT_TRIGGER_RESET,
+				WM_DIRECTIONAL_CROSS_MOTION,
+				WM_DIRECTIONAL_CROSS_RESET,
+				WM_CONTROLLER_BUTTON_PRESS,
+				WM_CONTROLLER_BUTTON_RELEASE};
+			return eventIds;
+		}
 		enum class Type
 		{
 			Unknow,
@@ -193,8 +213,12 @@ namespace spk
 
 	struct SystemEvent : public IEvent
 	{
-		static inline std::vector<UINT> EventIDs = {
-			WM_SIZE, WM_SETFOCUS, WM_KILLFOCUS, WM_CLOSE, WM_QUIT, WM_MOVE, WM_ENTERSIZEMOVE, WM_EXITSIZEMOVE, WM_SETCURSOR};
+		static const std::vector<UINT> &eventIDs()
+		{
+			static const std::vector<UINT> eventIds = {
+				WM_SIZE, WM_SETFOCUS, WM_KILLFOCUS, WM_CLOSE, WM_QUIT, WM_MOVE, WM_ENTERSIZEMOVE, WM_EXITSIZEMOVE, WM_SETCURSOR};
+			return eventIds;
+		}
 		enum class Type
 		{
 			Unknow,
@@ -214,7 +238,11 @@ namespace spk
 
 	struct TimerEvent : public IEvent
 	{
-		static inline std::vector<UINT> EventIDs = {WM_TIMER};
+		static const std::vector<UINT> &eventIDs()
+		{
+			static const std::vector<UINT> eventIds = {WM_TIMER};
+			return eventIds;
+		}
 		enum class Type
 		{
 			Unknow,

--- a/include/widget/spk_widget.hpp
+++ b/include/widget/spk_widget.hpp
@@ -49,7 +49,11 @@ namespace spk
 		void _requestPaint();
 
 	private:
-		static inline std::array<spk::SafePointer<Widget>, 3> _focusedWidgets = {nullptr, nullptr, nullptr};
+		static std::array<spk::SafePointer<Widget>, 3> &_focusedWidgets()
+		{
+			static std::array<spk::SafePointer<Widget>, 3> focusedWidgets = {nullptr, nullptr, nullptr};
+			return focusedWidgets;
+		}
 
 		std::wstring _name;
 		spk::SafePointer<Widget> _parent;

--- a/src/structure/engine/spk_collider.cpp
+++ b/src/structure/engine/spk_collider.cpp
@@ -19,8 +19,8 @@ namespace spk
 	{
 		std::vector<spk::SafePointer<const Collider>> result;
 
-		std::lock_guard<std::mutex> lock(_collidersMutex);
-		for (const auto &body : _colliders)
+		std::lock_guard<std::mutex> lock(_collidersMutex());
+		for (const auto &body : _colliders())
 		{
 			if (body.get() == this)
 			{
@@ -48,18 +48,18 @@ namespace spk
 	void Collider::awake()
 	{
 		{
-			std::lock_guard<std::mutex> lock(_collidersMutex);
-			_colliders.push_back(this);
+			std::lock_guard<std::mutex> lock(_collidersMutex());
+			_colliders().push_back(this);
 		}
 		_updateCollisionCache();
 	}
 
 	void Collider::sleep()
 	{
-		std::lock_guard<std::mutex> lock(_collidersMutex);
-		auto it =
-			std::remove_if(_colliders.begin(), _colliders.end(), [this](const spk::SafePointer<Collider> &p_ptr) { return (p_ptr.get() == this); });
-		_colliders.erase(it, _colliders.end());
+		std::lock_guard<std::mutex> lock(_collidersMutex());
+		auto it = std::remove_if(
+			_colliders().begin(), _colliders().end(), [this](const spk::SafePointer<Collider> &p_ptr) { return (p_ptr.get() == this); });
+		_colliders().erase(it, _colliders().end());
 	}
 
 	void Collider::setCollisionMesh(const spk::SafePointer<const spk::CollisionMesh> &p_collisionMesh)
@@ -75,8 +75,8 @@ namespace spk
 
 	const std::vector<spk::SafePointer<Collider>> &Collider::getColliders()
 	{
-		std::lock_guard<std::mutex> lock(_collidersMutex);
-		return (_colliders);
+		std::lock_guard<std::mutex> lock(_collidersMutex());
+		return (_colliders());
 	}
 
 	namespace

--- a/src/structure/engine/spk_collider_2d.cpp
+++ b/src/structure/engine/spk_collider_2d.cpp
@@ -19,9 +19,9 @@ namespace spk
 	{
 		std::vector<spk::SafePointer<const Collider2D>> result;
 
-		std::lock_guard<std::mutex> lock(_collidersMutex);
+		std::lock_guard<std::mutex> lock(_collidersMutex());
 
-		for (const auto &body : _colliders)
+		for (const auto &body : _colliders())
 		{
 			if (body.get() == this)
 			{
@@ -51,18 +51,18 @@ namespace spk
 	void Collider2D::awake()
 	{
 		{
-			std::lock_guard<std::mutex> lock(_collidersMutex);
-			_colliders.push_back(this);
+			std::lock_guard<std::mutex> lock(_collidersMutex());
+			_colliders().push_back(this);
 		}
 		_updateCollisionCache();
 	}
 
 	void Collider2D::sleep()
 	{
-		std::lock_guard<std::mutex> lock(_collidersMutex);
-		auto it =
-			std::remove_if(_colliders.begin(), _colliders.end(), [this](const spk::SafePointer<Collider2D> &p_ptr) { return p_ptr.get() == this; });
-		_colliders.erase(it, _colliders.end());
+		std::lock_guard<std::mutex> lock(_collidersMutex());
+		auto it = std::remove_if(
+			_colliders().begin(), _colliders().end(), [this](const spk::SafePointer<Collider2D> &p_ptr) { return p_ptr.get() == this; });
+		_colliders().erase(it, _colliders().end());
 	}
 
 	void Collider2D::setCollisionMesh(const spk::SafePointer<const spk::CollisionMesh2D> &p_collisionMesh)
@@ -78,8 +78,8 @@ namespace spk
 
 	const std::vector<spk::SafePointer<Collider2D>> &Collider2D::getColliders()
 	{
-		std::lock_guard<std::mutex> lock(_collidersMutex);
-		return (_colliders);
+		std::lock_guard<std::mutex> lock(_collidersMutex());
+		return (_colliders());
 	}
 
 	namespace

--- a/src/structure/engine/spk_obj_mesh.cpp
+++ b/src/structure/engine/spk_obj_mesh.cpp
@@ -71,21 +71,21 @@ namespace spk
 	void ObjMesh::setMaterial(const std::filesystem::path &p_materialPath)
 	{
 		_materialPath = p_materialPath;
-		auto it = _materials.find(p_materialPath);
-		if (it == _materials.end())
+		auto it = _materials().find(p_materialPath);
+		if (it == _materials().end())
 		{
 			spk::Image image;
 			image.loadFromFile(p_materialPath);
-			_materials.emplace(p_materialPath, std::move(image));
-			it = _materials.find(p_materialPath);
+			_materials().emplace(p_materialPath, std::move(image));
+			it = _materials().find(p_materialPath);
 		}
 		_onMaterialChangeProvider.trigger(spk::SafePointer<spk::Texture>(&it->second));
 	}
 
 	spk::SafePointer<const spk::Texture> ObjMesh::material() const
 	{
-		auto it = _materials.find(_materialPath);
-		if (it == _materials.end())
+		auto it = _materials().find(_materialPath);
+		if (it == _materials().end())
 		{
 			return (spk::SafePointer<const spk::Texture>(nullptr));
 		}

--- a/src/structure/graphics/painter/spk_color_painter.cpp
+++ b/src/structure/graphics/painter/spk_color_painter.cpp
@@ -8,7 +8,7 @@ namespace spk
 {
 	void ColorPainter::_initProgram()
 	{
-		if (_program == nullptr)
+		if (_program() == nullptr)
 		{
 			const char *vertexShaderSrc = R"(#version 450
 			
@@ -39,7 +39,7 @@ namespace spk
 				}
 				)";
 
-			_program = std::make_unique<spk::OpenGL::Program>(vertexShaderSrc, fragmentShaderSrc);
+			_program() = std::make_unique<spk::OpenGL::Program>(vertexShaderSrc, fragmentShaderSrc);
 		}
 	}
 
@@ -101,14 +101,14 @@ namespace spk
 
 	void ColorPainter::render()
 	{
-		_program->activate();
+		_program()->activate();
 		_bufferSet.activate();
 		_colorUniformBufferObject.activate();
 
-		_program->render(_bufferSet.indexes().nbIndexes(), 1);
+		_program()->render(_bufferSet.indexes().nbIndexes(), 1);
 
 		_colorUniformBufferObject.deactivate();
 		_bufferSet.deactivate();
-		_program->deactivate();
+		_program()->deactivate();
 	}
 }

--- a/src/structure/graphics/painter/spk_font_painter.cpp
+++ b/src/structure/graphics/painter/spk_font_painter.cpp
@@ -8,7 +8,7 @@ namespace spk
 {
 	void FontPainter::_initProgram()
 	{
-		if (_program == nullptr)
+		if (_program() == nullptr)
 		{
 			const char *vertexShaderSrc = R"(#version 450
 
@@ -73,7 +73,7 @@ void main()
     outputColor = vec4(color, alpha);
 })";
 
-			_program = std::make_unique<spk::OpenGL::Program>(vertexShaderSrc, fragmentShaderSrc);
+			_program() = std::make_unique<spk::OpenGL::Program>(vertexShaderSrc, fragmentShaderSrc);
 		}
 	}
 
@@ -259,7 +259,7 @@ void main()
 
 			for (size_t i = 0; i < 6; i++)
 			{
-				_bufferSet.indexes() << (baseIndexes + spk::Font::Glyph::indexesOrder[i]);
+				_bufferSet.indexes() << (baseIndexes + spk::Font::Glyph::indexesOrder()[i]);
 			}
 
 			baseIndexes += 4;
@@ -297,16 +297,16 @@ void main()
 			return;
 		}
 
-		_program->activate();
+		_program()->activate();
 		_bufferSet.activate();
 		_samplerObject.activate();
 		_textInformationsUniformBufferObject.activate();
 
-		_program->render(_bufferSet.indexes().nbIndexes(), 1);
+		_program()->render(_bufferSet.indexes().nbIndexes(), 1);
 
 		_textInformationsUniformBufferObject.deactivate();
 		_samplerObject.deactivate();
 		_bufferSet.deactivate();
-		_program->deactivate();
+		_program()->deactivate();
 	}
 }

--- a/src/structure/graphics/painter/spk_texture_painter.cpp
+++ b/src/structure/graphics/painter/spk_texture_painter.cpp
@@ -10,7 +10,7 @@ namespace spk
 {
 	void TexturePainter::_initProgram()
 	{
-		if (_program == nullptr)
+		if (_program() == nullptr)
 		{
 			const char *vertexShaderSrc = R"(#version 450
 			
@@ -42,7 +42,7 @@ namespace spk
 				}
 				)";
 
-			_program = std::make_unique<spk::OpenGL::Program>(vertexShaderSrc, fragmentShaderSrc);
+			_program() = std::make_unique<spk::OpenGL::Program>(vertexShaderSrc, fragmentShaderSrc);
 		}
 	}
 
@@ -120,14 +120,14 @@ namespace spk
 			return;
 		}
 
-		_program->activate();
+		_program()->activate();
 		_bufferSet.activate();
 		_samplerObject.activate();
 
-		_program->render(_bufferSet.indexes().nbIndexes(), 1);
+		_program()->render(_bufferSet.indexes().nbIndexes(), 1);
 
 		_samplerObject.deactivate();
 		_bufferSet.deactivate();
-		_program->deactivate();
+		_program()->deactivate();
 	}
 }

--- a/src/structure/graphics/texture/spk_texture.cpp
+++ b/src/structure/graphics/texture/spk_texture.cpp
@@ -10,11 +10,11 @@ namespace spk
 	{
 		Texture::ID result;
 
-		if (_availableIDs.empty() == false)
+		if (_availableIDs().empty() == false)
 		{
-			result = _availableIDs.back();
+			result = _availableIDs().back();
 
-			_availableIDs.pop_back();
+			_availableIDs().pop_back();
 		}
 		else
 		{
@@ -32,7 +32,7 @@ namespace spk
 			return;
 		}
 
-		_availableIDs.push_back(p_id);
+		_availableIDs().push_back(p_id);
 	}
 
 	Texture::Section::Section() :

--- a/src/structure/spk_iostream.cpp
+++ b/src/structure/spk_iostream.cpp
@@ -19,7 +19,7 @@ namespace spk
 		}
 
 		{
-			std::lock_guard<std::recursive_mutex> lock(_mutex);
+			std::lock_guard<std::recursive_mutex> lock(_mutex());
 			if (!_prefix.empty())
 			{
 				*_outputStream << "[" << _prefix << "] - ";
@@ -46,13 +46,13 @@ namespace spk
 
 	void IOStream::setPrefix(const std::wstring &p_prefix)
 	{
-		std::lock_guard<std::recursive_mutex> lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex());
 		_prefix = p_prefix;
 	}
 
 	void IOStream::redirect(std::wostream &p_outputStream)
 	{
-		std::lock_guard<std::recursive_mutex> lock(_mutex);
+		std::lock_guard<std::recursive_mutex> lock(_mutex());
 		_outputStream = &p_outputStream;
 	}
 

--- a/src/widget/spk_widget.cpp
+++ b/src/widget/spk_widget.cpp
@@ -176,7 +176,7 @@ namespace spk
 
 	spk::SafePointer<Widget> Widget::focusedWidget(FocusType p_focusType)
 	{
-		return (_focusedWidgets[static_cast<int>(p_focusType)]);
+		return (_focusedWidgets()[static_cast<int>(p_focusType)]);
 	}
 
 	void Widget::_requestPaint()
@@ -186,14 +186,14 @@ namespace spk
 
 	void Widget::takeFocus(FocusType p_focusType)
 	{
-		_focusedWidgets[static_cast<int>(p_focusType)] = this;
+		_focusedWidgets()[static_cast<int>(p_focusType)] = this;
 	}
 
 	void Widget::releaseFocus(FocusType p_focusType)
 	{
-		if (_focusedWidgets[static_cast<int>(p_focusType)] == this)
+		if (_focusedWidgets()[static_cast<int>(p_focusType)] == this)
 		{
-			_focusedWidgets[static_cast<int>(p_focusType)] = nullptr;
+			_focusedWidgets()[static_cast<int>(p_focusType)] = nullptr;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- replace eager static members with accessor functions for lazy instantiation
- adjust callers to use new accessors

## Testing
- `cmake --preset test-debug` *(fails: Could not find toolchain file: /scripts/buildsystems/vcpkg.cmake)*
- `clang-tidy src/widget/spk_widget.cpp -- -std=c++20` *(fails: 1 error generated)*

------
https://chatgpt.com/codex/tasks/task_e_68c032de35c4832596300506a5e40c97