### PR TITLE
Refactor shader object ownership

### DIFF
--- a/include/structure/engine/spk_collision_mesh_2d_renderer.hpp
+++ b/include/structure/engine/spk_collision_mesh_2d_renderer.hpp
@@ -21,7 +21,7 @@ namespace spk
 
 			spk::Lumina::Shader::Object _object;
 			spk::OpenGL::BufferSet &_bufferSet;
-			std::shared_ptr<spk::OpenGL::UniformBufferObject> _transformUBO;
+			spk::OpenGL::UniformBufferObject &_transformUBO;
 
 		public:
 			Painter();

--- a/include/structure/engine/spk_collision_mesh_renderer.hpp
+++ b/include/structure/engine/spk_collision_mesh_renderer.hpp
@@ -21,7 +21,7 @@ namespace spk
 
 			spk::Lumina::Shader::Object _object;
 			spk::OpenGL::BufferSet &_bufferSet;
-			std::shared_ptr<spk::OpenGL::UniformBufferObject> _transformUBO;
+			spk::OpenGL::UniformBufferObject &_transformUBO;
 
 		public:
 			Painter();

--- a/include/structure/engine/spk_color_mesh_renderer.hpp
+++ b/include/structure/engine/spk_color_mesh_renderer.hpp
@@ -21,7 +21,7 @@ namespace spk
 
 			spk::Lumina::Shader::Object _object;
 			spk::OpenGL::BufferSet &_bufferSet;
-			std::shared_ptr<spk::OpenGL::UniformBufferObject> _transformUBO;
+			spk::OpenGL::UniformBufferObject &_transformUBO;
 
 		public:
 			Painter();

--- a/include/structure/engine/spk_mesh_2d_renderer.hpp
+++ b/include/structure/engine/spk_mesh_2d_renderer.hpp
@@ -22,9 +22,8 @@ namespace spk
 
 			spk::Lumina::Shader::Object _object;
 			spk::OpenGL::BufferSet &_bufferSet;
-			std::shared_ptr<spk::OpenGL::SamplerObject> _diffuseSampler;
-			;
-			std::shared_ptr<spk::OpenGL::UniformBufferObject> _transformUBO;
+			spk::OpenGL::SamplerObject &_diffuseSampler;
+			spk::OpenGL::UniformBufferObject &_transformUBO;
 
 		public:
 			Painter();

--- a/include/structure/engine/spk_obj_mesh_renderer.hpp
+++ b/include/structure/engine/spk_obj_mesh_renderer.hpp
@@ -22,9 +22,8 @@ namespace spk
 
 			spk::Lumina::Shader::Object _object;
 			spk::OpenGL::BufferSet &_bufferSet;
-			std::shared_ptr<spk::OpenGL::SamplerObject> _diffuseSampler;
-			;
-			std::shared_ptr<spk::OpenGL::UniformBufferObject> _transformUBO;
+			spk::OpenGL::SamplerObject &_diffuseSampler;
+			spk::OpenGL::UniformBufferObject &_transformUBO;
 
 		public:
 			Painter();

--- a/include/structure/graphics/lumina/spk_shader.hpp
+++ b/include/structure/graphics/lumina/spk_shader.hpp
@@ -198,7 +198,7 @@ namespace spk::Lumina
 		{
 			_program.activate();
 
-			for (const auto &[name, object] : _availableObjects)
+			for (auto &[name, object] : _availableObjects)
 			{
 				visitVariant(object, [&](auto &p_object) { p_object.activate(); });
 			}
@@ -218,7 +218,7 @@ namespace spk::Lumina
 		{
 			_program.deactivate();
 
-			for (const auto &[name, object] : _availableObjects)
+			for (auto &[name, object] : _availableObjects)
 			{
 				visitVariant(object, [&](auto &p_object) { p_object.deactivate(); });
 			}

--- a/include/structure/graphics/lumina/spk_shader.hpp
+++ b/include/structure/graphics/lumina/spk_shader.hpp
@@ -17,10 +17,7 @@ namespace spk::Lumina
 	class Shader
 	{
 	private:
-		using Unit = std::variant<
-			std::shared_ptr<OpenGL::SamplerObject>,
-			std::shared_ptr<OpenGL::UniformBufferObject>,
-			std::shared_ptr<OpenGL::ShaderStorageBufferObject>>;
+		using Unit = std::variant<OpenGL::SamplerObject, OpenGL::UniformBufferObject, OpenGL::ShaderStorageBufferObject>;
 
 	public:
 		enum class Mode
@@ -50,20 +47,9 @@ namespace spk::Lumina
 				_originator(p_originator),
 				_bufferSet(p_originator->_bufferSet)
 			{
-				for (const auto& [name, attribute] : p_originator->_attributes)
+				for (const auto &[name, attribute] : p_originator->_attributes)
 				{
-					if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(attribute) == true)
-					{
-						_attributes[name] = std::make_shared<OpenGL::SamplerObject>(*(std::get<std::shared_ptr<OpenGL::SamplerObject>>(attribute)));
-					}
-					if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(attribute) == true)
-					{
-						_attributes[name] = std::make_shared<OpenGL::UniformBufferObject>(*(std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(attribute)));
-					}
-					if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(attribute) == true)
-					{
-						_attributes[name] = std::make_shared<OpenGL::ShaderStorageBufferObject>(*(std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(attribute)));
-					}
+					_attributes[name] = attribute;
 				}
 			}
 
@@ -73,7 +59,7 @@ namespace spk::Lumina
 
 				for (auto &[name, object] : _attributes)
 				{
-					visitVariant(object, [&](auto &p_object) { p_object->activate(); });
+					visitVariant(object, [&](auto &p_object) { p_object.activate(); });
 				}
 			}
 
@@ -83,7 +69,7 @@ namespace spk::Lumina
 
 				for (auto &[name, object] : _attributes)
 				{
-					visitVariant(object, [&](auto &p_object) { p_object->deactivate(); });
+					visitVariant(object, [&](auto &p_object) { p_object.deactivate(); });
 				}
 			}
 
@@ -118,11 +104,10 @@ namespace spk::Lumina
 			{
 				return (
 					_originator->containSampler(p_name) ||
-					(_attributes.contains(p_name) == true &&
-					 std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_attributes.at(p_name)) == true));
+					(_attributes.contains(p_name) == true && std::holds_alternative<OpenGL::SamplerObject>(_attributes.at(p_name)) == true));
 			}
 
-			std::shared_ptr<OpenGL::SamplerObject> sampler(const std::wstring &p_name)
+			OpenGL::SamplerObject &sampler(const std::wstring &p_name)
 			{
 				if (_attributes.contains(p_name) == false)
 				{
@@ -136,22 +121,21 @@ namespace spk::Lumina
 							"' not found in spk::Lumina::Shader constants or object attributes.");
 					}
 				}
-				if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_attributes.at(p_name)) == false)
+				if (std::holds_alternative<OpenGL::SamplerObject>(_attributes.at(p_name)) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not a sampler object.");
 				}
-				return std::get<std::shared_ptr<OpenGL::SamplerObject>>(_attributes.at(p_name));
+				return std::get<OpenGL::SamplerObject>(_attributes.at(p_name));
 			}
 
 			bool containUBO(const std::wstring &p_name) const
 			{
 				return (
 					_originator->containUBO(p_name) ||
-					(_attributes.contains(p_name) == true &&
-					 std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_attributes.at(p_name)) == true));
+					(_attributes.contains(p_name) == true && std::holds_alternative<OpenGL::UniformBufferObject>(_attributes.at(p_name)) == true));
 			}
 
-			std::shared_ptr<OpenGL::UniformBufferObject> ubo(const std::wstring &p_name)
+			OpenGL::UniformBufferObject &ubo(const std::wstring &p_name)
 			{
 				if (_attributes.contains(p_name) == false)
 				{
@@ -165,22 +149,21 @@ namespace spk::Lumina
 							"' not found in spk::Lumina::Shader constants or object attributes.");
 					}
 				}
-				if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_attributes.at(p_name)) == false)
+				if (std::holds_alternative<OpenGL::UniformBufferObject>(_attributes.at(p_name)) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not a UBO.");
 				}
-				return std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(_attributes.at(p_name));
+				return std::get<OpenGL::UniformBufferObject>(_attributes.at(p_name));
 			}
 
 			bool containSSBO(const std::wstring &p_name) const
 			{
 				return (
-					_originator->containSSBO(p_name) ||
-					(_attributes.contains(p_name) == true &&
-					 std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_attributes.at(p_name)) == true));
+					_originator->containSSBO(p_name) || (_attributes.contains(p_name) == true &&
+														 std::holds_alternative<OpenGL::ShaderStorageBufferObject>(_attributes.at(p_name)) == true));
 			}
 
-			std::shared_ptr<OpenGL::ShaderStorageBufferObject> ssbo(const std::wstring &p_name)
+			OpenGL::ShaderStorageBufferObject &ssbo(const std::wstring &p_name)
 			{
 				if (_attributes.contains(p_name) == false)
 				{
@@ -194,11 +177,11 @@ namespace spk::Lumina
 							"' not found in spk::Lumina::Shader constants or object attributes.");
 					}
 				}
-				if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_attributes.at(p_name)) == false)
+				if (std::holds_alternative<OpenGL::ShaderStorageBufferObject>(_attributes.at(p_name)) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not an SSBO.");
 				}
-				return std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_attributes.at(p_name));
+				return std::get<OpenGL::ShaderStorageBufferObject>(_attributes.at(p_name));
 			}
 		};
 
@@ -217,7 +200,7 @@ namespace spk::Lumina
 
 			for (const auto &[name, object] : _availableObjects)
 			{
-				visitVariant(object, [&](auto &p_object) { p_object->activate(); });
+				visitVariant(object, [&](auto &p_object) { p_object.activate(); });
 			}
 		}
 
@@ -237,11 +220,11 @@ namespace spk::Lumina
 
 			for (const auto &[name, object] : _availableObjects)
 			{
-				visitVariant(object, [&](auto &p_object) { p_object->deactivate(); });
+				visitVariant(object, [&](auto &p_object) { p_object.deactivate(); });
 			}
 		}
 
-		void _addSamplerConstant(const std::wstring &p_name, const std::shared_ptr<OpenGL::SamplerObject> &p_object)
+		void _addSamplerConstant(const std::wstring &p_name, const OpenGL::SamplerObject &p_object)
 		{
 			if (_objects.contains(p_name) == false)
 			{
@@ -249,26 +232,25 @@ namespace spk::Lumina
 			}
 			else
 			{
-				if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_objects[p_name]) == false)
+				if (std::holds_alternative<OpenGL::SamplerObject>(_objects[p_name]) == false)
 				{
 					throw std::runtime_error(
 						"Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not a sampler object.");
 				}
 
-				spk::SafePointer<std::shared_ptr<OpenGL::SamplerObject>> sampler =
-					&(std::get<std::shared_ptr<OpenGL::SamplerObject>>(_objects[p_name]));
+				spk::SafePointer<OpenGL::SamplerObject> sampler = &(std::get<OpenGL::SamplerObject>(_objects[p_name]));
 
 				// No size verification to compute on samplers
 			}
 
-			_availableObjects[p_name] = std::get<std::shared_ptr<OpenGL::SamplerObject>>(_objects[p_name]);
+			_availableObjects[p_name] = std::get<OpenGL::SamplerObject>(_objects[p_name]);
 		}
 
-		void _addSamplerAttribute(const std::wstring &p_name, const std::shared_ptr<OpenGL::SamplerObject> &p_object)
+		void _addSamplerAttribute(const std::wstring &p_name, const OpenGL::SamplerObject &p_object)
 		{
 			if (_attributes.contains(p_name) == true)
 			{
-				if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_attributes[p_name]) == false)
+				if (std::holds_alternative<OpenGL::SamplerObject>(_attributes[p_name]) == false)
 				{
 					throw std::runtime_error(
 						"Attribute with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not a sampler object.");
@@ -280,7 +262,7 @@ namespace spk::Lumina
 			_attributes[p_name] = p_object;
 		}
 
-		void _addUboConstant(const std::wstring &p_name, const std::shared_ptr<OpenGL::UniformBufferObject> &p_object)
+		void _addUboConstant(const std::wstring &p_name, const OpenGL::UniformBufferObject &p_object)
 		{
 			if (_objects.contains(p_name) == false)
 			{
@@ -288,37 +270,37 @@ namespace spk::Lumina
 			}
 			else
 			{
-				if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_objects[p_name]) == false)
+				if (std::holds_alternative<OpenGL::UniformBufferObject>(_objects[p_name]) == false)
 				{
 					throw std::runtime_error(
 						"Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not an UBO.");
 				}
 
-				std::shared_ptr<OpenGL::UniformBufferObject> ubo = std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(_objects[p_name]);
+				OpenGL::UniformBufferObject &ubo = std::get<OpenGL::UniformBufferObject>(_objects[p_name]);
 
-				if (ubo->size() != p_object->size())
+				if (ubo.size() != p_object.size())
 				{
 					throw std::runtime_error(
-						"UBO size mismatch for '" + spk::StringUtils::wstringToString(p_name) + "'. Expected: " + std::to_string(ubo->size()) +
-						", got: " + std::to_string(p_object->size()));
+						"UBO size mismatch for '" + spk::StringUtils::wstringToString(p_name) + "'. Expected: " + std::to_string(ubo.size()) +
+						", got: " + std::to_string(p_object.size()));
 				}
 
-				if (ubo->bindingPoint() != p_object->bindingPoint())
+				if (ubo.bindingPoint() != p_object.bindingPoint())
 				{
 					throw std::runtime_error(
 						"UBO binding point mismatch for '" + spk::StringUtils::wstringToString(p_name) +
-						"'. Expected: " + std::to_string(ubo->bindingPoint()) + ", got: " + std::to_string(p_object->bindingPoint()));
+						"'. Expected: " + std::to_string(ubo.bindingPoint()) + ", got: " + std::to_string(p_object.bindingPoint()));
 				}
 			}
 
-			_availableObjects[p_name] = std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(_objects[p_name]);
+			_availableObjects[p_name] = std::get<OpenGL::UniformBufferObject>(_objects[p_name]);
 		}
 
-		void _addUboAttribute(const std::wstring &p_name, const std::shared_ptr<OpenGL::UniformBufferObject> &p_object)
+		void _addUboAttribute(const std::wstring &p_name, const OpenGL::UniformBufferObject &p_object)
 		{
 			if (_attributes.contains(p_name) == true)
 			{
-				if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_attributes[p_name]) == false)
+				if (std::holds_alternative<OpenGL::UniformBufferObject>(_attributes[p_name]) == false)
 				{
 					throw std::runtime_error(
 						"Attribute with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not an UBO object.");
@@ -330,7 +312,7 @@ namespace spk::Lumina
 			_attributes[p_name] = p_object;
 		}
 
-		void _addSsboConstant(const std::wstring &p_name, const std::shared_ptr<OpenGL::ShaderStorageBufferObject> &p_object)
+		void _addSsboConstant(const std::wstring &p_name, const OpenGL::ShaderStorageBufferObject &p_object)
 		{
 			if (_objects.contains(p_name) == false)
 			{
@@ -338,45 +320,44 @@ namespace spk::Lumina
 			}
 			else
 			{
-				if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_objects[p_name]) == false)
+				if (std::holds_alternative<OpenGL::ShaderStorageBufferObject>(_objects[p_name]) == false)
 				{
 					throw std::runtime_error(
 						"Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not an SSBO.");
 				}
 
-				std::shared_ptr<OpenGL::ShaderStorageBufferObject> ssbo =
-					std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_objects[p_name]);
+				OpenGL::ShaderStorageBufferObject &ssbo = std::get<OpenGL::ShaderStorageBufferObject>(_objects[p_name]);
 
-				if (ssbo->fixedData().size() != p_object->fixedData().size())
+				if (ssbo.fixedData().size() != p_object.fixedData().size())
 				{
 					throw std::runtime_error(
 						"SSBO fixed data size mismatch for '" + spk::StringUtils::wstringToString(p_name) +
-						"'. Expected: " + std::to_string(ssbo->fixedData().size()) + ", got: " + std::to_string(p_object->fixedData().size()));
+						"'. Expected: " + std::to_string(ssbo.fixedData().size()) + ", got: " + std::to_string(p_object.fixedData().size()));
 				}
 
-				if (ssbo->dynamicArray().elementSize() != p_object->dynamicArray().elementSize())
+				if (ssbo.dynamicArray().elementSize() != p_object.dynamicArray().elementSize())
 				{
 					throw std::runtime_error(
 						"SSBO dynamic array element size mismatch for '" + spk::StringUtils::wstringToString(p_name) + "'. Expected: " +
-						std::to_string(ssbo->dynamicArray().elementSize()) + ", got: " + std::to_string(p_object->dynamicArray().elementSize()));
+						std::to_string(ssbo.dynamicArray().elementSize()) + ", got: " + std::to_string(p_object.dynamicArray().elementSize()));
 				}
 
-				if (ssbo->bindingPoint() != p_object->bindingPoint())
+				if (ssbo.bindingPoint() != p_object.bindingPoint())
 				{
 					throw std::runtime_error(
 						"SSBO binding point mismatch for '" + spk::StringUtils::wstringToString(p_name) +
-						"'. Expected: " + std::to_string(ssbo->bindingPoint()) + ", got: " + std::to_string(p_object->bindingPoint()));
+						"'. Expected: " + std::to_string(ssbo.bindingPoint()) + ", got: " + std::to_string(p_object.bindingPoint()));
 				}
 			}
 
-			_availableObjects[p_name] = std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_objects[p_name]);
+			_availableObjects[p_name] = std::get<OpenGL::ShaderStorageBufferObject>(_objects[p_name]);
 		}
 
-		void _addSsboAttribute(const std::wstring &p_name, const std::shared_ptr<OpenGL::ShaderStorageBufferObject> &p_object)
+		void _addSsboAttribute(const std::wstring &p_name, const OpenGL::ShaderStorageBufferObject &p_object)
 		{
 			if (_attributes.contains(p_name) == true)
 			{
-				if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_attributes[p_name]) == false)
+				if (std::holds_alternative<OpenGL::ShaderStorageBufferObject>(_attributes[p_name]) == false)
 				{
 					throw std::runtime_error(
 						"Attribute with name '" + spk::StringUtils::wstringToString(p_name) + "' is already set but is not an SSBO.");
@@ -411,103 +392,102 @@ namespace spk::Lumina
 			_bufferSet.layout().addAttribute(p_index, p_type);
 		}
 
-		void addSampler(const std::wstring &p_name, const std::shared_ptr<OpenGL::SamplerObject> &p_object, Mode p_mode)
+		void addSampler(const std::wstring &p_name, const OpenGL::SamplerObject &p_object, Mode p_mode)
 		{
 			if (p_mode == Mode::Constant)
 			{
-				_addSamplerConstant(p_name, std::move(p_object));
+				_addSamplerConstant(p_name, p_object);
 			}
 			else
 			{
-				_addSamplerAttribute(p_name, std::move(p_object));
+				_addSamplerAttribute(p_name, p_object);
 			}
 		}
 
-		void addUBO(const std::wstring &p_name, const std::shared_ptr<OpenGL::UniformBufferObject> &p_object, Mode p_mode)
+		void addUBO(const std::wstring &p_name, const OpenGL::UniformBufferObject &p_object, Mode p_mode)
 		{
 			if (p_mode == Mode::Constant)
 			{
-				_addUboConstant(p_name, std::move(p_object));
+				_addUboConstant(p_name, p_object);
 			}
 			else
 			{
-				_addUboAttribute(p_name, std::move(p_object));
+				_addUboAttribute(p_name, p_object);
 			}
 		}
 
-		void addSSBO(const std::wstring &p_name, const std::shared_ptr<OpenGL::ShaderStorageBufferObject> &p_object, Mode p_mode)
+		void addSSBO(const std::wstring &p_name, const OpenGL::ShaderStorageBufferObject &p_object, Mode p_mode)
 		{
 			if (p_mode == Mode::Constant)
 			{
-				_addSsboConstant(p_name, std::move(p_object));
+				_addSsboConstant(p_name, p_object);
 			}
 			else
 			{
-				_addSsboAttribute(p_name, std::move(p_object));
+				_addSsboAttribute(p_name, p_object);
 			}
 		}
 
 		bool containSampler(const std::wstring &p_name) const
 		{
 			return (
-				_availableObjects.contains(p_name) == true &&
-				std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_availableObjects.at(p_name)) == true);
+				_availableObjects.contains(p_name) == true && std::holds_alternative<OpenGL::SamplerObject>(_availableObjects.at(p_name)) == true);
 		}
 
-		std::shared_ptr<OpenGL::SamplerObject> sampler(const std::wstring &p_name)
+		OpenGL::SamplerObject &sampler(const std::wstring &p_name)
 		{
 			if (_availableObjects.contains(p_name) == false)
 			{
 				throw std::runtime_error(
 					"Sampler with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants.");
 			}
-			if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(_availableObjects.at(p_name)) == false)
+			if (std::holds_alternative<OpenGL::SamplerObject>(_availableObjects.at(p_name)) == false)
 			{
 				throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not a sampler object.");
 			}
-			return std::get<std::shared_ptr<OpenGL::SamplerObject>>(_availableObjects.at(p_name));
+			return std::get<OpenGL::SamplerObject>(_availableObjects.at(p_name));
 		}
 
 		bool containUBO(const std::wstring &p_name) const
 		{
 			return (
 				_availableObjects.contains(p_name) == true &&
-				std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_availableObjects.at(p_name)) == true);
+				std::holds_alternative<OpenGL::UniformBufferObject>(_availableObjects.at(p_name)) == true);
 		}
 
-		std::shared_ptr<OpenGL::UniformBufferObject> ubo(const std::wstring &p_name)
+		OpenGL::UniformBufferObject &ubo(const std::wstring &p_name)
 		{
 			if (_availableObjects.contains(p_name) == false)
 			{
 				throw std::runtime_error(
 					"UBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants.");
 			}
-			if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(_availableObjects.at(p_name)) == false)
+			if (std::holds_alternative<OpenGL::UniformBufferObject>(_availableObjects.at(p_name)) == false)
 			{
 				throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not a UBO.");
 			}
-			return std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(_availableObjects.at(p_name));
+			return std::get<OpenGL::UniformBufferObject>(_availableObjects.at(p_name));
 		}
 
 		bool containSSBO(const std::wstring &p_name) const
 		{
 			return (
 				_availableObjects.contains(p_name) == true &&
-				std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_availableObjects.at(p_name)) == true);
+				std::holds_alternative<OpenGL::ShaderStorageBufferObject>(_availableObjects.at(p_name)) == true);
 		}
 
-		std::shared_ptr<OpenGL::ShaderStorageBufferObject> ssbo(const std::wstring &p_name)
+		OpenGL::ShaderStorageBufferObject &ssbo(const std::wstring &p_name)
 		{
 			if (_availableObjects.contains(p_name) == false)
 			{
 				throw std::runtime_error(
 					"SSBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found in spk::Lumina::Shader constants.");
 			}
-			if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_availableObjects.at(p_name)) == false)
+			if (std::holds_alternative<OpenGL::ShaderStorageBufferObject>(_availableObjects.at(p_name)) == false)
 			{
 				throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not an SSBO.");
 			}
-			return std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(_availableObjects.at(p_name));
+			return std::get<OpenGL::ShaderStorageBufferObject>(_availableObjects.at(p_name));
 		}
 
 		Object createObject()
@@ -517,88 +497,87 @@ namespace spk::Lumina
 
 		struct Constants
 		{
-			static void addSampler(const std::wstring &p_name, const std::shared_ptr<OpenGL::SamplerObject> &p_object)
+			static void addSampler(const std::wstring &p_name, const OpenGL::SamplerObject &p_object)
 			{
 				if (_objects.contains(p_name) == false)
 				{
-					_objects[p_name] = std::move(p_object);
+					_objects[p_name] = p_object;
 				}
 			}
 
-			static void addUBO(const std::wstring &p_name, const std::shared_ptr<OpenGL::UniformBufferObject> &p_object)
+			static void addUBO(const std::wstring &p_name, const OpenGL::UniformBufferObject &p_object)
 			{
 				if (_objects.contains(p_name) == false)
 				{
-					_objects[p_name] = std::move(p_object);
+					_objects[p_name] = p_object;
 				}
 			}
 
-			static void addSSBO(const std::wstring &p_name, const std::shared_ptr<OpenGL::ShaderStorageBufferObject> &p_object)
+			static void addSSBO(const std::wstring &p_name, const OpenGL::ShaderStorageBufferObject &p_object)
 			{
 				if (_objects.contains(p_name) == false)
 				{
-					_objects[p_name] = std::move(p_object);
+					_objects[p_name] = p_object;
 				}
 			}
 
 			static bool containsSampler(const std::wstring &p_name)
 			{
 				return (
-					Shader::_objects.contains(p_name) == true &&
-					std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(Shader::_objects.at(p_name)) == true);
+					Shader::_objects.contains(p_name) == true && std::holds_alternative<OpenGL::SamplerObject>(Shader::_objects.at(p_name)) == true);
 			}
 
 			static bool containsUBO(const std::wstring &p_name)
 			{
 				return (
 					Shader::_objects.contains(p_name) == true &&
-					std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(Shader::_objects.at(p_name)) == true);
+					std::holds_alternative<OpenGL::UniformBufferObject>(Shader::_objects.at(p_name)) == true);
 			}
 
 			static bool containsSSBO(const std::wstring &p_name)
 			{
 				return (
 					Shader::_objects.contains(p_name) == true &&
-					std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(Shader::_objects.at(p_name)) == true);
+					std::holds_alternative<OpenGL::ShaderStorageBufferObject>(Shader::_objects.at(p_name)) == true);
 			}
 
-			static std::shared_ptr<OpenGL::SamplerObject> &sampler(const std::wstring &p_name)
+			static OpenGL::SamplerObject &sampler(const std::wstring &p_name)
 			{
 				if (Shader::_objects.contains(p_name) == false)
 				{
 					throw std::runtime_error("Sampler with name '" + spk::StringUtils::wstringToString(p_name) + "' not found.");
 				}
-				if (std::holds_alternative<std::shared_ptr<OpenGL::SamplerObject>>(Shader::_objects[p_name]) == false)
+				if (std::holds_alternative<OpenGL::SamplerObject>(Shader::_objects[p_name]) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not an Sampler.");
 				}
-				return (std::get<std::shared_ptr<OpenGL::SamplerObject>>(Shader::_objects[p_name]));
+				return (std::get<OpenGL::SamplerObject>(Shader::_objects[p_name]));
 			}
 
-			static std::shared_ptr<OpenGL::UniformBufferObject> &ubo(const std::wstring &p_name)
+			static OpenGL::UniformBufferObject &ubo(const std::wstring &p_name)
 			{
 				if (Shader::_objects.contains(p_name) == false)
 				{
 					throw std::runtime_error("UBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found.");
 				}
-				if (std::holds_alternative<std::shared_ptr<OpenGL::UniformBufferObject>>(Shader::_objects[p_name]) == false)
+				if (std::holds_alternative<OpenGL::UniformBufferObject>(Shader::_objects[p_name]) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not an UBO.");
 				}
-				return (std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(Shader::_objects[p_name]));
+				return (std::get<OpenGL::UniformBufferObject>(Shader::_objects[p_name]));
 			}
 
-			static std::shared_ptr<OpenGL::ShaderStorageBufferObject> &ssbo(const std::wstring &p_name)
+			static OpenGL::ShaderStorageBufferObject &ssbo(const std::wstring &p_name)
 			{
 				if (Shader::_objects.contains(p_name) == false)
 				{
 					throw std::runtime_error("SSBO with name '" + spk::StringUtils::wstringToString(p_name) + "' not found.");
 				}
-				if (std::holds_alternative<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(Shader::_objects[p_name]) == false)
+				if (std::holds_alternative<OpenGL::ShaderStorageBufferObject>(Shader::_objects[p_name]) == false)
 				{
 					throw std::runtime_error("Object with name '" + spk::StringUtils::wstringToString(p_name) + "' is not an SSBO.");
 				}
-				return (std::get<std::shared_ptr<OpenGL::ShaderStorageBufferObject>>(Shader::_objects[p_name]));
+				return (std::get<OpenGL::ShaderStorageBufferObject>(Shader::_objects[p_name]));
 			}
 		};
 	};

--- a/include/structure/graphics/lumina/spk_shader_object_factory.hpp
+++ b/include/structure/graphics/lumina/spk_shader_object_factory.hpp
@@ -17,10 +17,7 @@ namespace spk::Lumina
 		friend class spk::Singleton<ShaderObjectFactory>;
 
 	private:
-		using Object = std::variant<
-			std::shared_ptr<OpenGL::UniformBufferObject>,
-			std::shared_ptr<OpenGL::ShaderStorageBufferObject>,
-			std::shared_ptr<OpenGL::SamplerObject>>;
+		using Object = std::variant<OpenGL::UniformBufferObject, OpenGL::ShaderStorageBufferObject, OpenGL::SamplerObject>;
 
 		std::unordered_map<std::wstring, Object> _objects;
 
@@ -33,8 +30,8 @@ namespace spk::Lumina
 	public:
 		void add(const spk::JSON::Object &p_desc);
 
-		std::shared_ptr<OpenGL::UniformBufferObject> ubo(const std::wstring &p_name);
-		std::shared_ptr<OpenGL::ShaderStorageBufferObject> ssbo(const std::wstring &p_name);
-		std::shared_ptr<OpenGL::SamplerObject> sampler(const std::wstring &p_name);
+		const OpenGL::UniformBufferObject &ubo(const std::wstring &p_name);
+		const OpenGL::ShaderStorageBufferObject &ssbo(const std::wstring &p_name);
+		const OpenGL::SamplerObject &sampler(const std::wstring &p_name);
 	};
 }

--- a/src/structure/engine/spk_camera_component.cpp
+++ b/src/structure/engine/spk_camera_component.cpp
@@ -10,9 +10,9 @@ namespace spk
 	{
 		auto &cameraUBO = spk::Lumina::Shader::Constants::ubo(L"CameraUBO");
 		const spk::Transform &transform = owner()->transform();
-		cameraUBO->layout()[L"viewMatrix"] = transform.inverseModel();
-		cameraUBO->layout()[L"projectionMatrix"] = _camera.projectionMatrix();
-		cameraUBO->validate();
+		cameraUBO.layout()[L"viewMatrix"] = transform.inverseModel();
+		cameraUBO.layout()[L"projectionMatrix"] = _camera.projectionMatrix();
+		cameraUBO.validate();
 	}
 
 	CameraComponent::CameraComponent(const std::wstring &p_name) :

--- a/src/structure/engine/spk_collision_mesh_2d_renderer.cpp
+++ b/src/structure/engine/spk_collision_mesh_2d_renderer.cpp
@@ -130,8 +130,8 @@ outputColor = vec4(color, 1.0);
 
 	void CollisionMesh2DRenderer::Painter::setTransform(const spk::Transform &p_transform)
 	{
-		_transformUBO->layout()[L"modelMatrix"] = p_transform.model();
-		_transformUBO->validate();
+		_transformUBO.layout()[L"modelMatrix"] = p_transform.model();
+		_transformUBO.validate();
 	}
 
 	CollisionMesh2DRenderer::CollisionMesh2DRenderer(const std::wstring &p_name) :

--- a/src/structure/engine/spk_collision_mesh_renderer.cpp
+++ b/src/structure/engine/spk_collision_mesh_renderer.cpp
@@ -130,8 +130,8 @@ void main()
 
 	void CollisionMeshRenderer::Painter::setTransform(const spk::Transform &p_transform)
 	{
-		_transformUBO->layout()[L"modelMatrix"] = p_transform.model();
-		_transformUBO->validate();
+		_transformUBO.layout()[L"modelMatrix"] = p_transform.model();
+		_transformUBO.validate();
 	}
 
 	CollisionMeshRenderer::CollisionMeshRenderer(const std::wstring &p_name) :

--- a/src/structure/engine/spk_color_mesh_renderer.cpp
+++ b/src/structure/engine/spk_color_mesh_renderer.cpp
@@ -92,8 +92,8 @@ void main()
 
 	void ColorMeshRenderer::Painter::setTransform(const spk::Transform &p_transform)
 	{
-		_transformUBO->layout()[L"modelMatrix"] = p_transform.model();
-		_transformUBO->validate();
+		_transformUBO.layout()[L"modelMatrix"] = p_transform.model();
+		_transformUBO.validate();
 	}
 
 	ColorMeshRenderer::ColorMeshRenderer(const std::wstring &p_name) :

--- a/src/structure/engine/spk_mesh_2d_renderer.cpp
+++ b/src/structure/engine/spk_mesh_2d_renderer.cpp
@@ -109,18 +109,18 @@ outputColor = texColor;
 
 	void Mesh2DRenderer::Painter::setTransform(const spk::Transform &p_transform)
 	{
-		_transformUBO->layout()[L"modelMatrix"] = p_transform.model();
-		_transformUBO->validate();
+		_transformUBO.layout()[L"modelMatrix"] = p_transform.model();
+		_transformUBO.validate();
 	}
 
 	void Mesh2DRenderer::Painter::setTexture(const spk::SafePointer<const spk::Texture> &p_texture)
 	{
-		_diffuseSampler->bind(p_texture);
+		_diffuseSampler.bind(p_texture);
 	}
 
 	const spk::SafePointer<const spk::Texture> &Mesh2DRenderer::Painter::texture() const
 	{
-		return (_diffuseSampler->texture());
+		return (_diffuseSampler.texture());
 	}
 
 	Mesh2DRenderer::Mesh2DRenderer(const std::wstring &p_name) :

--- a/src/structure/engine/spk_obj_mesh_renderer.cpp
+++ b/src/structure/engine/spk_obj_mesh_renderer.cpp
@@ -110,18 +110,18 @@ void main()
 
 	void ObjMeshRenderer::Painter::setTransform(const spk::Transform &p_transform)
 	{
-		_transformUBO->layout()[L"modelMatrix"] = p_transform.model();
-		_transformUBO->validate();
+		_transformUBO.layout()[L"modelMatrix"] = p_transform.model();
+		_transformUBO.validate();
 	}
 
 	void ObjMeshRenderer::Painter::setTexture(const spk::SafePointer<const spk::Texture> &p_texture)
 	{
-		_diffuseSampler->bind(p_texture);
+		_diffuseSampler.bind(p_texture);
 	}
 
 	const spk::SafePointer<const spk::Texture> &ObjMeshRenderer::Painter::texture() const
 	{
-		return (_diffuseSampler->texture());
+		return (_diffuseSampler.texture());
 	}
 
 	ObjMeshRenderer::ObjMeshRenderer(const std::wstring &p_name) :

--- a/src/structure/graphics/lumina/spk_shader_object_factory.cpp
+++ b/src/structure/graphics/lumina/spk_shader_object_factory.cpp
@@ -27,12 +27,12 @@ namespace spk::Lumina
 			const JSON::Object &desc = p_ubos[index];
 			std::wstring name = desc[L"name"].as<std::wstring>();
 			const JSON::Object &data = desc[L"data"];
-			std::shared_ptr<OpenGL::UniformBufferObject> newUBO = std::make_shared<OpenGL::UniformBufferObject>(data);
+			OpenGL::UniformBufferObject newUBO(data);
 
 			if (_objects.contains(name))
 			{
-				auto &existing = std::get<std::shared_ptr<OpenGL::UniformBufferObject>>(_objects[name]);
-				if (existing->size() != newUBO->size())
+				auto &existing = std::get<OpenGL::UniformBufferObject>(_objects[name]);
+				if (existing.size() != newUBO.size())
 				{
 					GENERATE_ERROR("UBO '" + StringUtils::wstringToString(name) + "' already exists with a different size.");
 				}
@@ -51,13 +51,13 @@ namespace spk::Lumina
 			const spk::JSON::Object &desc = p_ssbos[index];
 			std::wstring name = desc[L"name"].as<std::wstring>();
 			const spk::JSON::Object &data = desc[L"data"];
-			std::shared_ptr<OpenGL::ShaderStorageBufferObject> newSSBO = std::make_shared<OpenGL::ShaderStorageBufferObject>(data);
+			OpenGL::ShaderStorageBufferObject newSSBO(data);
 
 			if (_objects.contains(name))
 			{
-				auto &existing = std::get<std::shared_ptr<spk::OpenGL::ShaderStorageBufferObject>>(_objects[name]);
-				if (existing->fixedData().size() != newSSBO->fixedData().size() ||
-					existing->dynamicArray().elementSize() != newSSBO->dynamicArray().elementSize())
+				auto &existing = std::get<spk::OpenGL::ShaderStorageBufferObject>(_objects[name]);
+				if (existing.fixedData().size() != newSSBO.fixedData().size() ||
+					existing.dynamicArray().elementSize() != newSSBO.dynamicArray().elementSize())
 				{
 					GENERATE_ERROR("SSBO '" + spk::StringUtils::wstringToString(name) + "' already exists with a different size.");
 				}
@@ -76,12 +76,12 @@ namespace spk::Lumina
 			const spk::JSON::Object &desc = p_samplers[index];
 			std::wstring alias = desc[L"name"].as<std::wstring>();
 			const spk::JSON::Object &data = desc[L"data"];
-			std::shared_ptr<OpenGL::SamplerObject> newSampler = std::make_shared<OpenGL::SamplerObject>(data);
+			OpenGL::SamplerObject newSampler(data);
 
 			if (_objects.contains(alias))
 			{
-				auto &existing = std::get<std::shared_ptr<spk::OpenGL::SamplerObject>>(_objects[alias]);
-				if (existing->bindingPoint() != newSampler->bindingPoint() || existing->type() != newSampler->type())
+				auto &existing = std::get<spk::OpenGL::SamplerObject>(_objects[alias]);
+				if (existing.bindingPoint() != newSampler.bindingPoint() || existing.type() != newSampler.type())
 				{
 					GENERATE_ERROR(
 						"Sampler '" + spk::StringUtils::wstringToString(alias) + "' already exists with a different binding point or type.");
@@ -94,18 +94,18 @@ namespace spk::Lumina
 		}
 	}
 
-	std::shared_ptr<spk::OpenGL::UniformBufferObject> ShaderObjectFactory::ubo(const std::wstring &p_name)
+	const OpenGL::UniformBufferObject &ShaderObjectFactory::ubo(const std::wstring &p_name)
 	{
-		return (std::get<std::shared_ptr<spk::OpenGL::UniformBufferObject>>(_objects.at(p_name)));
+		return std::get<spk::OpenGL::UniformBufferObject>(_objects.at(p_name));
 	}
 
-	std::shared_ptr<spk::OpenGL::ShaderStorageBufferObject> ShaderObjectFactory::ssbo(const std::wstring &p_name)
+	const OpenGL::ShaderStorageBufferObject &ShaderObjectFactory::ssbo(const std::wstring &p_name)
 	{
-		return (std::get<std::shared_ptr<spk::OpenGL::ShaderStorageBufferObject>>(_objects.at(p_name)));
+		return std::get<spk::OpenGL::ShaderStorageBufferObject>(_objects.at(p_name));
 	}
 
-	std::shared_ptr<spk::OpenGL::SamplerObject> ShaderObjectFactory::sampler(const std::wstring &p_name)
+	const OpenGL::SamplerObject &ShaderObjectFactory::sampler(const std::wstring &p_name)
 	{
-		return (std::get<std::shared_ptr<spk::OpenGL::SamplerObject>>(_objects.at(p_name)));
+		return std::get<spk::OpenGL::SamplerObject>(_objects.at(p_name));
 	}
 }


### PR DESCRIPTION
## Summary
- store shader resources by value and accept const references
- have shader object factory return const references
- update renderers to work with reference-based shader objects

## Testing
- `clang-tidy src/structure/graphics/lumina/spk_shader_object_factory.cpp src/structure/engine/spk_mesh_2d_renderer.cpp src/structure/engine/spk_obj_mesh_renderer.cpp src/structure/engine/spk_color_mesh_renderer.cpp src/structure/engine/spk_collision_mesh_renderer.cpp src/structure/engine/spk_collision_mesh_2d_renderer.cpp -- -Iinclude` *(fails: 'GL/glew.h' file not found)*
- `cmake --preset test-debug` *(fails: Could not find toolchain file: /scripts/buildsystems/vcpkg.cmake)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68c13a984d5083258f742b33f74d6c12