### PR TITLE
Fix SSBO dynamic array buffer after copy or move

### DIFF
--- a/playground/src/main.cpp
+++ b/playground/src/main.cpp
@@ -42,8 +42,7 @@ private:
 			{Shape::Type::Pentagon, 5},
 			{Shape::Type::Hexagon, 6},
 			{Shape::Type::Octogon, 8},
-			{Shape::Type::Circle, 30}
-		};
+			{Shape::Type::Circle, 30}};
 		ShapeMesh result;
 
 		std::vector<spk::Vector2> vertices;
@@ -150,7 +149,7 @@ void main()
 				spk::cout() << "Fixed data size : " << infoSSBO.fixedData().size() << std::endl;
 				spk::cout() << "Dynamic array element size : " << infoSSBO.dynamicArray().elementSize() << std::endl;
 				spk::cout() << "Dynamic array nb element : " << infoSSBO.dynamicArray().nbElement() << std::endl;
-				spk::cout() << " --------------------------" << std::endl << std::endl; 
+				spk::cout() << " --------------------------" << std::endl << std::endl;
 
 				shader.addSSBO(L"InfoSSBO", infoSSBO, spk::Lumina::Shader::Mode::Attribute);
 
@@ -160,7 +159,7 @@ void main()
 
 			spk::Lumina::Shader::Object _object;
 			spk::OpenGL::BufferSet &_bufferSet;
-			spk::OpenGL::ShaderStorageBufferObject& _infoSSBO;
+			spk::OpenGL::ShaderStorageBufferObject &_infoSSBO;
 
 			spk::SafePointer<const InfoContainer> _infoContainer;
 
@@ -188,11 +187,23 @@ void main()
 				spk::cout() << "Fixed data size : " << _infoSSBO.fixedData().size() << std::endl;
 				spk::cout() << "Dynamic array element size : " << _infoSSBO.dynamicArray().elementSize() << std::endl;
 				spk::cout() << "Dynamic array nb element : " << _infoSSBO.dynamicArray().nbElement() << std::endl;
-				spk::cout() << " --------------------------" << std::endl << std::endl; 
+				spk::cout() << " --------------------------" << std::endl << std::endl;
 				_prepare(p_mesh);
 			}
 
-			const spk::OpenGL::ShaderStorageBufferObject& infoSSBO() const
+			Painter(Painter &&p_other) :
+				_object(std::move(p_other._object)),
+				_bufferSet(_object.bufferSet()),
+				_infoSSBO(_object.ssbo(L"InfoSSBO")),
+				_infoContainer(std::move(p_other._infoContainer))
+			{
+			}
+
+			Painter(const Painter &) = delete;
+			Painter &operator=(const Painter &) = delete;
+			Painter &operator=(Painter &&) = delete;
+
+			const spk::OpenGL::ShaderStorageBufferObject &infoSSBO() const
 			{
 				return (_infoSSBO);
 			}
@@ -221,7 +232,7 @@ void main()
 				spk::cout() << "Fixed data size : " << _infoSSBO.fixedData().size() << std::endl;
 				spk::cout() << "Dynamic array element size : " << _infoSSBO.dynamicArray().elementSize() << std::endl;
 				spk::cout() << "Dynamic array nb element : " << _infoSSBO.dynamicArray().nbElement() << std::endl;
-				spk::cout() << " --------------------------" << std::endl << std::endl; 
+				spk::cout() << " --------------------------" << std::endl << std::endl;
 
 				auto &array = _infoSSBO.dynamicArray();
 
@@ -354,7 +365,7 @@ private:
 
 			_iterator->model = owner()->transform().model();
 			_iterator->color = _color;
-			
+
 			Renderer::validate(_type.value());
 		}
 
@@ -377,7 +388,7 @@ private:
 			_bind();
 		}
 
-		void setColor(const spk::Color& p_color)
+		void setColor(const spk::Color &p_color)
 		{
 			_color = p_color;
 			if (_type.has_value() == true)
@@ -426,7 +437,7 @@ public:
 		_subscriber->setType(p_type);
 	}
 
-	void setColor(const spk::Color& p_color)
+	void setColor(const spk::Color &p_color)
 	{
 		_subscriber->setColor(p_color);
 	}

--- a/src/structure/graphics/opengl/spk_shader_storage_buffer_object.cpp
+++ b/src/structure/graphics/opengl/spk_shader_storage_buffer_object.cpp
@@ -126,10 +126,9 @@ namespace spk::OpenGL
 		_fixedData(L"FixedData", &dataBuffer(), 0, 0),
 		_dynamicArray(L"DynamicArray", &dataBuffer(), 0, 0, 0)
 	{
-		_onResizeContract = _dynamicArray._resizeContractProvider.subscribe([&](size_t p_size) {
-			resize(p_size);
-		});
+		_onResizeContract = _dynamicArray._resizeContractProvider.subscribe([&](size_t p_size) { resize(p_size); });
 		_dynamicArray._buffer = &dataBuffer();
+		_dynamicArray._defaultElement.setBuffer(&dataBuffer());
 	}
 
 	ShaderStorageBufferObject::ShaderStorageBufferObject(
@@ -150,6 +149,7 @@ namespace spk::OpenGL
 		resize(p_fixedSize + p_paddingFixedToDynamic + p_dynamicElementSize);
 		_onResizeContract = _dynamicArray._resizeContractProvider.subscribe([&](size_t p_size) { resize(p_size); });
 		_dynamicArray._buffer = &dataBuffer();
+		_dynamicArray._defaultElement.setBuffer(&dataBuffer());
 		_dynamicArray._redoArray();
 	}
 
@@ -201,6 +201,8 @@ namespace spk::OpenGL
 		// DynamicArray _dynamicArray;
 
 		_dynamicArray._buffer = &dataBuffer();
+		_dynamicArray._defaultElement.setBuffer(&dataBuffer());
+		_fixedData.setBuffer(&dataBuffer());
 		resize(p_other.size());
 		_onResizeContract = _dynamicArray._resizeContractProvider.subscribe([&](size_t p_size) { resize(p_size); });
 		_dynamicArray._redoArray();
@@ -219,6 +221,8 @@ namespace spk::OpenGL
 			resize(p_other.size());
 			_onResizeContract = _dynamicArray._resizeContractProvider.subscribe([&](size_t p_size) { resize(p_size); });
 			_dynamicArray._buffer = &dataBuffer();
+			_dynamicArray._defaultElement.setBuffer(&dataBuffer());
+			_fixedData.setBuffer(&dataBuffer());
 			_dynamicArray._redoArray();
 		}
 		return *this;
@@ -232,9 +236,10 @@ namespace spk::OpenGL
 		_fixedData(std::move(p_other._fixedData)),
 		_dynamicArray(std::move(p_other._dynamicArray))
 	{
-		resize(p_other.size());
 		_onResizeContract = _dynamicArray._resizeContractProvider.subscribe([&](size_t p_size) { resize(p_size); });
 		_dynamicArray._buffer = &dataBuffer();
+		_dynamicArray._defaultElement.setBuffer(&dataBuffer());
+		_fixedData.setBuffer(&dataBuffer());
 		_dynamicArray._redoArray();
 	}
 
@@ -242,14 +247,16 @@ namespace spk::OpenGL
 	{
 		if (this != &p_other)
 		{
+			VertexBufferObject::operator=(std::move(p_other));
 			_blockName = std::move(p_other._blockName);
 			_bindingPoint = p_other._bindingPoint;
 			_blockIndex = p_other._blockIndex;
 			_fixedData = std::move(p_other._fixedData);
 			_dynamicArray = std::move(p_other._dynamicArray);
-			resize(p_other.size());
 			_onResizeContract = _dynamicArray._resizeContractProvider.subscribe([&](size_t p_size) { resize(p_size); });
 			_dynamicArray._buffer = &dataBuffer();
+			_dynamicArray._defaultElement.setBuffer(&dataBuffer());
+			_fixedData.setBuffer(&dataBuffer());
 			_dynamicArray._redoArray();
 		}
 		return *this;


### PR DESCRIPTION
## Summary
- Reset `ShaderStorageBufferObject` dynamic array's default element buffer whenever an SSBO is copied or moved to keep internal references valid
- Rebind fixed SSBO data to the current data buffer after copies or moves and rely on base move assignment to transfer the underlying buffer

## Testing
- `clang-tidy src/structure/graphics/opengl/spk_shader_storage_buffer_object.cpp -- -std=c++20 -Iinclude` *(fails: 'GL/glew.h' file not found)*
- `cmake --preset test-debug` *(fails: Could not find toolchain file: /scripts/buildsystems/vcpkg.cmake)*
- `cmake --build --preset test-debug` *(fails: No such file or directory)*
- `ctest --preset test-debug` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68c16d62629c83258ebaeae40cc89c55