### PR TITLE
Add comprehensive math structure tests

### DIFF
--- a/checker/include/structure/math/spk_edge_2d_tester.hpp
+++ b/checker/include/structure/math/spk_edge_2d_tester.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "structure/math/spk_edge_2d.hpp"
+#include <gtest/gtest.h>
+
+class Edge2DTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+};

--- a/checker/include/structure/math/spk_edge_map_2d_tester.hpp
+++ b/checker/include/structure/math/spk_edge_map_2d_tester.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "structure/math/spk_edge_map_2d.hpp"
+#include <gtest/gtest.h>
+
+class EdgeMap2DTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+};

--- a/checker/include/structure/math/spk_edge_map_tester.hpp
+++ b/checker/include/structure/math/spk_edge_map_tester.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "structure/math/spk_edge_map.hpp"
+#include <gtest/gtest.h>
+
+class EdgeMapTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+};

--- a/checker/include/structure/math/spk_edge_tester.hpp
+++ b/checker/include/structure/math/spk_edge_tester.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "structure/math/spk_edge.hpp"
+#include <gtest/gtest.h>
+
+class EdgeTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+};

--- a/checker/include/structure/math/spk_perlin_tester.hpp
+++ b/checker/include/structure/math/spk_perlin_tester.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "structure/math/spk_perlin.hpp"
+#include <gtest/gtest.h>
+
+class PerlinTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+};

--- a/checker/include/structure/math/spk_plane_tester.hpp
+++ b/checker/include/structure/math/spk_plane_tester.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "structure/math/spk_plane.hpp"
+#include <gtest/gtest.h>
+
+class PlaneTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+};

--- a/checker/include/structure/math/spk_polygon_2d_tester.hpp
+++ b/checker/include/structure/math/spk_polygon_2d_tester.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "structure/math/spk_polygon_2d.hpp"
+#include <gtest/gtest.h>
+
+class Polygon2DTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+};

--- a/checker/include/structure/math/spk_polygon_fuze_tester.hpp
+++ b/checker/include/structure/math/spk_polygon_fuze_tester.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "structure/math/spk_polygon.hpp"
+#include <gtest/gtest.h>
+
+class PolygonFuzeTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+};

--- a/checker/include/structure/math/spk_quaternion_tester.hpp
+++ b/checker/include/structure/math/spk_quaternion_tester.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "structure/math/spk_quaternion.hpp"
+#include <gtest/gtest.h>
+
+class QuaternionTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+};

--- a/checker/src/structure/math/spk_edge_2d_tester.cpp
+++ b/checker/src/structure/math/spk_edge_2d_tester.cpp
@@ -1,0 +1,33 @@
+#include "structure/math/spk_edge_2d_tester.hpp"
+
+TEST_F(Edge2DTest, OrientationContainmentAndProjection)
+{
+	spk::Edge2D edge(spk::Vector2(0.0f, 0.0f), spk::Vector2(1.0f, 0.0f));
+
+	EXPECT_GT(edge.orientation(spk::Vector2(0.5f, 1.0f)), 0.0f);
+	EXPECT_TRUE(edge.contains(spk::Vector2(0.3f, 0.0f), true));
+	EXPECT_FALSE(edge.contains(spk::Vector2(0.3f, 0.1f), true));
+	EXPECT_TRUE(edge.contains(spk::Vector2(0.3f, 0.1f), false));
+	EXPECT_NEAR(edge.project(spk::Vector2(0.5f, 0.0f)), 0.5f, 1e-6f);
+}
+
+TEST_F(Edge2DTest, DegenerateParallelAndColinear)
+{
+	spk::Edge2D flat(spk::Vector2(0.0f, 0.0f), spk::Vector2(0.0f, 0.0f));
+	spk::Edge2D colinear(spk::Vector2(1.0f, 0.0f), spk::Vector2(2.0f, 0.0f));
+	spk::Edge2D opposite(spk::Vector2(2.0f, 0.0f), spk::Vector2(1.0f, 0.0f));
+	spk::Edge2D vertical(spk::Vector2(0.0f, 0.0f), spk::Vector2(0.0f, 1.0f));
+
+	EXPECT_TRUE(flat.isParallel(spk::Edge2D(spk::Vector2(0.0f, 0.0f), spk::Vector2(0.0f, 0.0f))));
+	EXPECT_TRUE(colinear.isParallel(opposite));
+	EXPECT_FALSE(colinear.isParallel(vertical));
+
+	EXPECT_TRUE(colinear.isColinear(opposite));
+	EXPECT_TRUE(colinear.isInverse(opposite));
+	EXPECT_TRUE(colinear.isSame(opposite));
+	EXPECT_FALSE(colinear.isSame(vertical));
+
+	spk::Edge2D::Identifier id = spk::Edge2D::Identifier::from(opposite);
+	EXPECT_EQ(id.a, spk::Vector2(1.0f, 0.0f));
+	EXPECT_EQ(id.b, spk::Vector2(2.0f, 0.0f));
+}

--- a/checker/src/structure/math/spk_edge_map_2d_tester.cpp
+++ b/checker/src/structure/math/spk_edge_map_2d_tester.cpp
@@ -1,0 +1,40 @@
+#include "structure/math/spk_edge_map_2d_tester.hpp"
+
+#include "structure/math/spk_polygon_2d.hpp"
+
+TEST_F(EdgeMap2DTest, ConstructUnionFromTriangles)
+{
+	spk::Polygon2D triA = spk::Polygon2D::makeTriangle(spk::Vector2(0.0f, 0.0f), spk::Vector2(1.0f, 0.0f), spk::Vector2(0.0f, 1.0f));
+	spk::Polygon2D triB = spk::Polygon2D::makeTriangle(spk::Vector2(1.0f, 0.0f), spk::Vector2(1.0f, 1.0f), spk::Vector2(0.0f, 1.0f));
+
+	spk::EdgeMap2D map;
+	map.addPolygon(triA);
+	map.addPolygon(triB);
+
+	std::vector<spk::Polygon2D> result = map.construct();
+	ASSERT_EQ(result.size(), 1U);
+
+	const spk::Polygon2D &merged = result.front();
+	EXPECT_NEAR(merged.area(), 1.0f, 1e-4f);
+	EXPECT_TRUE(merged.contains(spk::Vector2(0.5f, 0.5f)));
+	EXPECT_FALSE(merged.contains(spk::Vector2(1.5f, 0.5f)));
+}
+
+TEST_F(EdgeMap2DTest, HandlesDisjointPolygons)
+{
+	spk::Polygon2D left =
+		spk::Polygon2D::makeSquare(spk::Vector2(-1.0f, -1.0f), spk::Vector2(0.0f, -1.0f), spk::Vector2(0.0f, 0.0f), spk::Vector2(-1.0f, 0.0f));
+	spk::Polygon2D right =
+		spk::Polygon2D::makeSquare(spk::Vector2(1.0f, -1.0f), spk::Vector2(2.0f, -1.0f), spk::Vector2(2.0f, 0.0f), spk::Vector2(1.0f, 0.0f));
+
+	spk::EdgeMap2D map;
+	map.addPolygon(left);
+	map.addPolygon(right);
+
+	std::vector<spk::Polygon2D> result = map.construct();
+	ASSERT_EQ(result.size(), 2U);
+	const bool leftContained = result[0].contains(spk::Vector2(-0.5f, -0.5f)) || result[1].contains(spk::Vector2(-0.5f, -0.5f));
+	const bool rightContained = result[0].contains(spk::Vector2(1.5f, -0.5f)) || result[1].contains(spk::Vector2(1.5f, -0.5f));
+	EXPECT_TRUE(leftContained);
+	EXPECT_TRUE(rightContained);
+}

--- a/checker/src/structure/math/spk_edge_map_tester.cpp
+++ b/checker/src/structure/math/spk_edge_map_tester.cpp
@@ -1,0 +1,40 @@
+#include "structure/math/spk_edge_map_tester.hpp"
+
+#include "structure/math/spk_polygon.hpp"
+
+TEST_F(EdgeMapTest, ConstructUnionFromTriangles)
+{
+	spk::Polygon triA = spk::Polygon::makeTriangle(spk::Vector3(0.0f, 0.0f, 0.0f), spk::Vector3(1.0f, 0.0f, 0.0f), spk::Vector3(0.0f, 1.0f, 0.0f));
+	spk::Polygon triB = spk::Polygon::makeTriangle(spk::Vector3(1.0f, 0.0f, 0.0f), spk::Vector3(1.0f, 1.0f, 0.0f), spk::Vector3(0.0f, 1.0f, 0.0f));
+
+	spk::EdgeMap map;
+	map.addPolygon(triA);
+	map.addPolygon(triB);
+
+	std::vector<spk::Polygon> result = map.construct();
+	ASSERT_EQ(result.size(), 1U);
+
+	const spk::Polygon &merged = result.front();
+	EXPECT_TRUE(merged.contains(spk::Vector3(0.5f, 0.5f, 0.0f)));
+	EXPECT_FALSE(merged.contains(spk::Vector3(1.5f, 0.5f, 0.0f)));
+	EXPECT_TRUE(merged.isPlanar());
+	EXPECT_TRUE(merged.isConvex());
+}
+
+TEST_F(EdgeMapTest, FiltersContainedLoops)
+{
+	spk::Polygon outer = spk::Polygon::makeSquare(
+		spk::Vector3(-1.0f, -1.0f, 0.0f), spk::Vector3(1.0f, -1.0f, 0.0f), spk::Vector3(1.0f, 1.0f, 0.0f), spk::Vector3(-1.0f, 1.0f, 0.0f));
+	spk::Polygon inner = spk::Polygon::makeSquare(
+		spk::Vector3(-0.5f, -0.5f, 0.0f), spk::Vector3(0.5f, -0.5f, 0.0f), spk::Vector3(0.5f, 0.5f, 0.0f), spk::Vector3(-0.5f, 0.5f, 0.0f));
+
+	spk::EdgeMap map;
+	map.addPolygon(outer);
+	map.addPolygon(inner);
+
+	std::vector<spk::Polygon> result = map.construct();
+	ASSERT_EQ(result.size(), 1U);
+	EXPECT_TRUE(result.front().contains(spk::Vector3(0.75f, 0.0f, 0.0f)));
+	EXPECT_TRUE(result.front().contains(spk::Vector3(0.0f, 0.0f, 0.0f)));
+	EXPECT_EQ(result.front().edges().size(), outer.edges().size());
+}

--- a/checker/src/structure/math/spk_edge_tester.cpp
+++ b/checker/src/structure/math/spk_edge_tester.cpp
@@ -1,0 +1,49 @@
+#include "structure/math/spk_edge_tester.hpp"
+
+#include <unordered_set>
+
+TEST_F(EdgeTest, ConstructorRejectsZeroLength)
+{
+	EXPECT_THROW(spk::Edge(spk::Vector3(0.0f, 0.0f, 0.0f), spk::Vector3(0.0f, 0.0f, 0.0f)), std::runtime_error);
+}
+
+TEST_F(EdgeTest, OrientationContainmentAndProjection)
+{
+	spk::Edge edge(spk::Vector3(0.0f, 0.0f, 0.0f), spk::Vector3(1.0f, 0.0f, 0.0f));
+
+	float orientation = edge.orientation(spk::Vector3(0.0f, 1.0f, 0.0f), spk::Vector3(0.0f, 0.0f, 1.0f));
+	EXPECT_GT(orientation, 0.0f);
+
+	EXPECT_TRUE(edge.contains(spk::Vector3(0.25f, 0.0f, 0.0f), true));
+	EXPECT_FALSE(edge.contains(spk::Vector3(0.5f, 0.1f, 0.0f), true));
+	EXPECT_TRUE(edge.contains(spk::Vector3(0.5f, 0.1f, 0.0f), false));
+	EXPECT_FALSE(edge.contains(spk::Vector3(1.5f, 0.0f, 0.0f), true));
+
+	EXPECT_NEAR(edge.project(spk::Vector3(0.5f, 0.0f, 0.0f)), 0.5f, 1e-6f);
+}
+
+TEST_F(EdgeTest, Relations)
+{
+	spk::Edge base(spk::Vector3(0.0f, 0.0f, 0.0f), spk::Vector3(1.0f, 0.0f, 0.0f));
+	spk::Edge forward(spk::Vector3(1.0f, 0.0f, 0.0f), spk::Vector3(2.0f, 0.0f, 0.0f));
+	spk::Edge backward(spk::Vector3(1.0f, 0.0f, 0.0f), spk::Vector3(0.0f, 0.0f, 0.0f));
+	spk::Edge skew(spk::Vector3(0.0f, 0.0f, 0.0f), spk::Vector3(0.0f, 1.0f, 0.0f));
+
+	EXPECT_TRUE(base.isParallel(forward));
+	EXPECT_TRUE(base.isParallel(backward));
+	EXPECT_FALSE(base.isParallel(skew));
+
+	EXPECT_TRUE(base.isColinear(forward));
+	EXPECT_TRUE(base.isInverse(backward));
+	EXPECT_TRUE(base.inverse().isInverse(base));
+
+	EXPECT_TRUE(base.isSame(backward));
+	EXPECT_FALSE(base.isSame(skew));
+
+	EXPECT_LT(spk::Edge::Identifier::from(base), spk::Edge::Identifier::from(backward));
+
+	std::unordered_set<spk::Edge> edges;
+	edges.insert(base);
+	edges.insert(backward);
+	EXPECT_EQ(edges.size(), 2U);
+}

--- a/checker/src/structure/math/spk_math_tester.cpp
+++ b/checker/src/structure/math/spk_math_tester.cpp
@@ -33,3 +33,17 @@ TEST(PositiveModuloTest, ZeroModulo)
 {
 	EXPECT_THROW(spk::positiveModulo(5, 0), std::invalid_argument);
 }
+
+TEST(DegreeRadianConversionTest, DegreeToRadian)
+{
+	EXPECT_FLOAT_EQ(spk::degreeToRadian(0.0f), 0.0f);
+	EXPECT_NEAR(spk::degreeToRadian(180.0f), static_cast<float>(M_PI), 1e-6f);
+	EXPECT_NEAR(spk::degreeToRadian(-90.0f), static_cast<float>(-M_PI / 2.0), 1e-6f);
+}
+
+TEST(DegreeRadianConversionTest, RadianToDegree)
+{
+	EXPECT_FLOAT_EQ(spk::radianToDegree(0.0f), 0.0f);
+	EXPECT_NEAR(spk::radianToDegree(static_cast<float>(M_PI)), 180.0f, 1e-5f);
+	EXPECT_NEAR(spk::radianToDegree(static_cast<float>(-M_PI / 2.0)), -90.0f, 1e-5f);
+}

--- a/checker/src/structure/math/spk_matrix_tester.cpp
+++ b/checker/src/structure/math/spk_matrix_tester.cpp
@@ -24,12 +24,7 @@ TEST_F(MatrixTest, MatrixConstructor)
 
 TEST_F(MatrixTest, MatrixConstructorOrder)
 {
-	float data[16] = {
-			2, 0, 0, 3,
-			0, 2, 0, 4,
-			0, 0, 2, 5,
-			0, 0, 0, 1
-	};
+	float data[16] = {2, 0, 0, 3, 0, 2, 0, 4, 0, 0, 2, 5, 0, 0, 0, 1};
 
 	spk::Matrix4x4 customMatrix = spk::Matrix4x4(data);
 
@@ -44,12 +39,7 @@ TEST_F(MatrixTest, MatrixConstructorOrder)
 
 TEST_F(MatrixTest, MatrixOnVector3Application)
 {
-	spk::Matrix4x4 customMatrix = spk::Matrix4x4({
-			2, 0, 0, 3,
-			0, 2, 0, 4,
-			0, 0, 2, 5,
-			0, 0, 0, 1
-		});
+	spk::Matrix4x4 customMatrix = spk::Matrix4x4({2, 0, 0, 3, 0, 2, 0, 4, 0, 0, 2, 5, 0, 0, 0, 1});
 
 	spk::Vector3 position = spk::Vector3(1, 2, 3);
 
@@ -60,11 +50,7 @@ TEST_F(MatrixTest, MatrixOnVector3Application)
 
 TEST_F(MatrixTest, MatrixOnVector2Application)
 {
-	spk::Matrix3x3 customMatrix = spk::Matrix3x3({
-		2, 0, 3,
-		0, 2, 4,
-		0, 0, 1
-		});
+	spk::Matrix3x3 customMatrix = spk::Matrix3x3({2, 0, 3, 0, 2, 4, 0, 0, 1});
 
 	spk::Vector2 position = spk::Vector2(1, 2);
 
@@ -75,26 +61,11 @@ TEST_F(MatrixTest, MatrixOnVector2Application)
 
 TEST_F(MatrixTest, MatrixComparator)
 {
-	spk::Matrix4x4 matrix = spk::Matrix4x4({
-			2, 0, 0, 3,
-			0, 2, 0, 4,
-			0, 0, 2, 5,
-			0, 0, 0, 1
-		});
+	spk::Matrix4x4 matrix = spk::Matrix4x4({2, 0, 0, 3, 0, 2, 0, 4, 0, 0, 2, 5, 0, 0, 0, 1});
 
-	spk::Matrix4x4 differentMatrix = spk::Matrix4x4({
-			2, 0, 0, 3,
-			0, 2, 0, 5,
-			0, 0, 2, 5,
-			0, 0, 0, 1
-		});
+	spk::Matrix4x4 differentMatrix = spk::Matrix4x4({2, 0, 0, 3, 0, 2, 0, 5, 0, 0, 2, 5, 0, 0, 0, 1});
 
-	spk::Matrix4x4 identicalMatrix = spk::Matrix4x4({
-			2, 0, 0, 3,
-			0, 2, 0, 4,
-			0, 0, 2, 5,
-			0, 0, 0, 1
-		});
+	spk::Matrix4x4 identicalMatrix = spk::Matrix4x4({2, 0, 0, 3, 0, 2, 0, 4, 0, 0, 2, 5, 0, 0, 0, 1});
 
 	EXPECT_NE(matrix, differentMatrix);
 	ASSERT_EQ(matrix, identicalMatrix);
@@ -102,66 +73,47 @@ TEST_F(MatrixTest, MatrixComparator)
 
 TEST_F(MatrixTest, MatrixToString)
 {
-	spk::Matrix4x4 matrix = spk::Matrix4x4({
-		2, 0, 0, 3,
-		0, 2, 0, 4,
-		0, 0, 2, 5,
-		0, 0, 0, 1
-		});
+	spk::Matrix4x4 matrix = spk::Matrix4x4({2, 0, 0, 3, 0, 2, 0, 4, 0, 0, 2, 5, 0, 0, 0, 1});
 
-	std::wstring expectedWideString =
-		L"[2 - 0 - 0 - 3] - "
-		L"[0 - 2 - 0 - 4] - "
-		L"[0 - 0 - 2 - 5] - "
-		L"[0 - 0 - 0 - 1]";
+	std::wstring expectedWideString = L"[2 - 0 - 0 - 3] - "
+									  L"[0 - 2 - 0 - 4] - "
+									  L"[0 - 0 - 2 - 5] - "
+									  L"[0 - 0 - 0 - 1]";
 
 	ASSERT_EQ(matrix.toWstring(), expectedWideString);
 
-	std::string expectedString =
-		"[2 - 0 - 0 - 3] - "
-		"[0 - 2 - 0 - 4] - "
-		"[0 - 0 - 2 - 5] - "
-		"[0 - 0 - 0 - 1]";
+	std::string expectedString = "[2 - 0 - 0 - 3] - "
+								 "[0 - 2 - 0 - 4] - "
+								 "[0 - 0 - 2 - 5] - "
+								 "[0 - 0 - 0 - 1]";
 
 	ASSERT_EQ(matrix.toString(), expectedString);
 }
 
 TEST_F(MatrixTest, MatrixOutputStream_wostream)
 {
-	spk::Matrix4x4 matrix = spk::Matrix4x4({
-		2, 0, 0, 3,
-		0, 2, 0, 4,
-		0, 0, 2, 5,
-		0, 0, 0, 1
-		});
+	spk::Matrix4x4 matrix = spk::Matrix4x4({2, 0, 0, 3, 0, 2, 0, 4, 0, 0, 2, 5, 0, 0, 0, 1});
 
 	std::wostringstream woss;
 	woss << matrix;
-	std::wstring expected =
-		L"[2 - 0 - 0 - 3] - "
-		L"[0 - 2 - 0 - 4] - "
-		L"[0 - 0 - 2 - 5] - "
-		L"[0 - 0 - 0 - 1]";
+	std::wstring expected = L"[2 - 0 - 0 - 3] - "
+							L"[0 - 2 - 0 - 4] - "
+							L"[0 - 0 - 2 - 5] - "
+							L"[0 - 0 - 0 - 1]";
 
 	ASSERT_EQ(woss.str(), expected);
 }
 
 TEST_F(MatrixTest, MatrixOutputStream_ostream)
 {
-	spk::Matrix4x4 matrix = spk::Matrix4x4({
-		2, 0, 0, 3,
-		0, 2, 0, 4,
-		0, 0, 2, 5,
-		0, 0, 0, 1
-		});
+	spk::Matrix4x4 matrix = spk::Matrix4x4({2, 0, 0, 3, 0, 2, 0, 4, 0, 0, 2, 5, 0, 0, 0, 1});
 
 	std::ostringstream oss;
 	oss << matrix;
-	std::string expected =
-		"[2 - 0 - 0 - 3] - "
-		"[0 - 2 - 0 - 4] - "
-		"[0 - 0 - 2 - 5] - "
-		"[0 - 0 - 0 - 1]";
+	std::string expected = "[2 - 0 - 0 - 3] - "
+						   "[0 - 2 - 0 - 4] - "
+						   "[0 - 0 - 2 - 5] - "
+						   "[0 - 0 - 0 - 1]";
 
 	ASSERT_EQ(oss.str(), expected);
 }
@@ -231,31 +183,30 @@ TEST_F(MatrixTest, RotateAroundAxisMatrix)
 TEST_F(MatrixTest, PerspectiveMatrix)
 {
 	float fov = 90.0f;
-    float aspectRatio = 1.0f;
-    float nearPlane = 0.1f;
-    float farPlane = 100.0f;
+	float aspectRatio = 1.0f;
+	float nearPlane = 0.1f;
+	float farPlane = 100.0f;
 
-    spk::Matrix4x4 perspectiveMatrix = spk::Matrix4x4::perspective(fov, aspectRatio, nearPlane, farPlane);
+	spk::Matrix4x4 perspectiveMatrix = spk::Matrix4x4::perspective(fov, aspectRatio, nearPlane, farPlane);
 
-    std::vector<std::pair<spk::Vector3, spk::Vector3>> values = {
-        {spk::Vector3(0.0f, 0.0f, 0.11f), 			spk::Vector3(0.0f, 0.0f, 2.822f)},
-        {spk::Vector3(0.0f, 0.0f, -1.0f), 			spk::Vector3(0.0f, 0.0f, 0.801802f)},
-        {spk::Vector3(1.0f, 1.0f, -10.0f), 			spk::Vector3(0.1f, 0.1f, 0.981982f)},
-        {spk::Vector3(-1.0f, -1.0f, -10.0f), 		spk::Vector3(-0.1f, -0.1f, 0.981982f)},
-        {spk::Vector3(10.0f, 10.0f, -10.0f), 		spk::Vector3(1, 1, 0.981982)},
-        {spk::Vector3(-10.0f, -10.0f, -10.0f), 		spk::Vector3(-1, -1, 0.981982)},
-        {spk::Vector3(100.0f, 100.0f, -10.0f), 		spk::Vector3(10.0f, 10.0f, 0.981982f)},
-        {spk::Vector3(-100.0f, -100.0f, -10.0f), 	spk::Vector3(-10.0f, -10.0f, 0.981982f)}
-    };
+	std::vector<std::pair<spk::Vector3, spk::Vector3>> values = {
+		{spk::Vector3(0.0f, 0.0f, 0.11f), spk::Vector3(0.0f, 0.0f, 2.822f)},
+		{spk::Vector3(0.0f, 0.0f, -1.0f), spk::Vector3(0.0f, 0.0f, 0.801802f)},
+		{spk::Vector3(1.0f, 1.0f, -10.0f), spk::Vector3(0.1f, 0.1f, 0.981982f)},
+		{spk::Vector3(-1.0f, -1.0f, -10.0f), spk::Vector3(-0.1f, -0.1f, 0.981982f)},
+		{spk::Vector3(10.0f, 10.0f, -10.0f), spk::Vector3(1, 1, 0.981982)},
+		{spk::Vector3(-10.0f, -10.0f, -10.0f), spk::Vector3(-1, -1, 0.981982)},
+		{spk::Vector3(100.0f, 100.0f, -10.0f), spk::Vector3(10.0f, 10.0f, 0.981982f)},
+		{spk::Vector3(-100.0f, -100.0f, -10.0f), spk::Vector3(-10.0f, -10.0f, 0.981982f)}};
 
-    ASSERT_EQ(perspectiveMatrix * values[0].first, values[0].second) << "Error in computed perspective position [" << 0 << "]";
-    ASSERT_EQ(perspectiveMatrix * values[1].first, values[1].second) << "Error in computed perspective position [" << 1 << "]";
-    ASSERT_EQ(perspectiveMatrix * values[2].first, values[2].second) << "Error in computed perspective position [" << 2 << "]";
-    ASSERT_EQ(perspectiveMatrix * values[3].first, values[3].second) << "Error in computed perspective position [" << 3 << "]";
-    ASSERT_EQ(perspectiveMatrix * values[4].first, values[4].second) << "Error in computed perspective position [" << 4 << "]";
-    ASSERT_EQ(perspectiveMatrix * values[5].first, values[5].second) << "Error in computed perspective position [" << 5 << "]";
-    ASSERT_EQ(perspectiveMatrix * values[6].first, values[6].second) << "Error in computed perspective position [" << 6 << "]";
-    ASSERT_EQ(perspectiveMatrix * values[7].first, values[7].second) << "Error in computed perspective position [" << 7 << "]";
+	ASSERT_EQ(perspectiveMatrix * values[0].first, values[0].second) << "Error in computed perspective position [" << 0 << "]";
+	ASSERT_EQ(perspectiveMatrix * values[1].first, values[1].second) << "Error in computed perspective position [" << 1 << "]";
+	ASSERT_EQ(perspectiveMatrix * values[2].first, values[2].second) << "Error in computed perspective position [" << 2 << "]";
+	ASSERT_EQ(perspectiveMatrix * values[3].first, values[3].second) << "Error in computed perspective position [" << 3 << "]";
+	ASSERT_EQ(perspectiveMatrix * values[4].first, values[4].second) << "Error in computed perspective position [" << 4 << "]";
+	ASSERT_EQ(perspectiveMatrix * values[5].first, values[5].second) << "Error in computed perspective position [" << 5 << "]";
+	ASSERT_EQ(perspectiveMatrix * values[6].first, values[6].second) << "Error in computed perspective position [" << 6 << "]";
+	ASSERT_EQ(perspectiveMatrix * values[7].first, values[7].second) << "Error in computed perspective position [" << 7 << "]";
 }
 
 TEST_F(MatrixTest, OrthoMatrix)
@@ -269,15 +220,53 @@ TEST_F(MatrixTest, OrthoMatrix)
 
 	spk::Matrix4x4 orthoMatrix = spk::Matrix4x4::ortho(left, right, bottom, top, nearPlane, farPlane);
 
-    std::vector<std::pair<spk::Vector3, spk::Vector3>> values = {
-        {spk::Vector3(5, 5, 0), spk::Vector3(0.5f, 0.5f, 0)},
-        {spk::Vector3(5, -5, 0.25), spk::Vector3(0.5f, -0.5f, -0.25)},
-        {spk::Vector3(-5, 5, 0.5), spk::Vector3(-0.5f, 0.5f, -0.5)},
-        {spk::Vector3(-5, -5, 0.75), spk::Vector3(-0.5f, -0.5f, -0.75)}
-    };
+	std::vector<std::pair<spk::Vector3, spk::Vector3>> values = {
+		{spk::Vector3(5, 5, 0), spk::Vector3(0.5f, 0.5f, 0)},
+		{spk::Vector3(5, -5, 0.25), spk::Vector3(0.5f, -0.5f, -0.25)},
+		{spk::Vector3(-5, 5, 0.5), spk::Vector3(-0.5f, 0.5f, -0.5)},
+		{spk::Vector3(-5, -5, 0.75), spk::Vector3(-0.5f, -0.5f, -0.75)}};
 
-    for (size_t i = 0; i < values.size(); i++)
-    {
-        ASSERT_EQ(orthoMatrix * values[i].first, values[i].second) << "Error in computed ortho position [" << i << "]";
-    }
+	for (size_t i = 0; i < values.size(); i++)
+	{
+		ASSERT_EQ(orthoMatrix * values[i].first, values[i].second) << "Error in computed ortho position [" << i << "]";
+	}
+}
+
+TEST_F(MatrixTest, DeterminantAndInverse)
+{
+	spk::Matrix2x2 matrix = spk::Matrix2x2({4.0f, 2.0f, 7.0f, 6.0f});
+
+	EXPECT_NEAR(matrix.determinant(), 10.0f, 1e-6f) << "Determinant should match the analytical value";
+	EXPECT_TRUE(matrix.isInvertible()) << "Matrix with non-zero determinant should be invertible";
+
+	spk::Matrix2x2 inverse = matrix.inverse();
+	spk::Matrix2x2 identity = matrix * inverse;
+
+	for (size_t column = 0; column < 2; ++column)
+	{
+		for (size_t row = 0; row < 2; ++row)
+		{
+			const float expected = (column == row ? 1.0f : 0.0f);
+			EXPECT_NEAR(identity[column][row], expected, 1e-5f) << "Product with inverse should yield the identity matrix";
+		}
+	}
+}
+
+TEST_F(MatrixTest, NonInvertibleMatrix)
+{
+	spk::Matrix3x3 matrix = spk::Matrix3x3({
+		1.0f,
+		0.0f,
+		0.0f,
+		2.0f,
+		0.0f,
+		0.0f,
+		3.0f,
+		0.0f,
+		0.0f,
+	});
+
+	EXPECT_FLOAT_EQ(matrix.determinant(), 0.0f) << "Determinant should be zero for singular matrix";
+	EXPECT_FALSE(matrix.isInvertible()) << "Matrix with zero determinant should not be invertible";
+	EXPECT_THROW(matrix.inverse(), std::runtime_error) << "Inversion should throw for singular matrix";
 }

--- a/checker/src/structure/math/spk_perlin_tester.cpp
+++ b/checker/src/structure/math/spk_perlin_tester.cpp
@@ -1,0 +1,41 @@
+#include "structure/math/spk_perlin_tester.hpp"
+
+#include <cmath>
+
+TEST_F(PerlinTest, DeterministicForSeed)
+{
+	spk::Perlin noise(1234u, spk::Perlin::Interpolation::SmoothStep);
+	float a = noise.sample1D(0.5f, -1.0f, 1.0f);
+	float b = noise.sample1D(0.5f, -1.0f, 1.0f);
+
+	EXPECT_FLOAT_EQ(a, b);
+	EXPECT_GE(a, -1.0f);
+	EXPECT_LE(a, 1.0f);
+}
+
+TEST_F(PerlinTest, DifferentSeedsProduceDifferentValues)
+{
+	spk::Perlin smooth(1337u, spk::Perlin::Interpolation::SmoothStep);
+	spk::Perlin linear(4242u, spk::Perlin::Interpolation::Linear);
+
+	float v1 = smooth.sample2D(0.25f, 0.75f, 0.0f, 1.0f);
+	float v2 = linear.sample2D(0.25f, 0.75f, 0.0f, 1.0f);
+
+	EXPECT_GE(v1, 0.0f);
+	EXPECT_LE(v1, 1.0f);
+	EXPECT_GE(v2, 0.0f);
+	EXPECT_LE(v2, 1.0f);
+	EXPECT_GT(std::fabs(v1 - v2), 1e-6f);
+}
+
+TEST_F(PerlinTest, Sample3DIsInRange)
+{
+	spk::Perlin noise(2024u, spk::Perlin::Interpolation::SmoothStep);
+
+	float min = -5.0f;
+	float max = 3.0f;
+	float value = noise.sample3D(0.1f, 0.2f, 0.3f, min, max);
+
+	EXPECT_GE(value, min);
+	EXPECT_LE(value, max);
+}

--- a/checker/src/structure/math/spk_plane_tester.cpp
+++ b/checker/src/structure/math/spk_plane_tester.cpp
@@ -1,0 +1,31 @@
+#include "structure/math/spk_plane_tester.hpp"
+
+#include "structure/math/spk_polygon.hpp"
+
+TEST_F(PlaneTest, IdentifierCanonicalizesNormal)
+{
+	spk::Plane plane(spk::Vector3(0.0f, 0.0f, 2.0f), spk::Vector3(0.0f, 0.0f, 1.0f));
+	spk::Plane flipped(spk::Vector3(0.0f, 0.0f, -2.0f), spk::Vector3(0.0f, 0.0f, 1.0f));
+
+	spk::Plane::Identifier a = spk::Plane::Identifier::from(plane);
+	spk::Plane::Identifier b = spk::Plane::Identifier::from(flipped);
+
+	EXPECT_EQ(a.normal, b.normal);
+	EXPECT_FLOAT_EQ(a.dotValue, b.dotValue);
+}
+
+TEST_F(PlaneTest, ContainsAndComparison)
+{
+	spk::Plane plane(spk::Vector3(0.0f, 0.0f, 1.0f), spk::Vector3(0.0f, 0.0f, 0.0f));
+	spk::Polygon square = spk::Polygon::makeSquare(
+		spk::Vector3(-1.0f, -1.0f, 0.0f), spk::Vector3(1.0f, -1.0f, 0.0f), spk::Vector3(1.0f, 1.0f, 0.0f), spk::Vector3(-1.0f, 1.0f, 0.0f));
+
+	EXPECT_TRUE(plane.contains(square));
+	EXPECT_TRUE(plane.contains(spk::Vector3(0.25f, -0.25f, 0.0f)));
+	EXPECT_FALSE(plane.contains(spk::Vector3(0.0f, 0.0f, 0.1f)));
+
+	spk::Plane offset(spk::Vector3(0.0f, 0.0f, -1.0f), spk::Vector3(0.0f, 0.0f, 1.0f));
+	EXPECT_TRUE(plane.isSame(offset));
+	EXPECT_FALSE(plane == offset);
+	EXPECT_NE(plane, offset);
+}

--- a/checker/src/structure/math/spk_polygon_2d_tester.cpp
+++ b/checker/src/structure/math/spk_polygon_2d_tester.cpp
@@ -1,0 +1,59 @@
+#include "structure/math/spk_polygon_2d_tester.hpp"
+
+#include <numeric>
+
+TEST_F(Polygon2DTest, AreaPerimeterAndCentroid)
+{
+	spk::Polygon2D square =
+		spk::Polygon2D::makeSquare(spk::Vector2(-1.0f, -1.0f), spk::Vector2(1.0f, -1.0f), spk::Vector2(1.0f, 1.0f), spk::Vector2(-1.0f, 1.0f));
+
+	EXPECT_NEAR(square.area(), 4.0f, 1e-5f);
+	EXPECT_NEAR(square.perimeter(), 8.0f, 1e-5f);
+	EXPECT_EQ(square.centroid(), spk::Vector2(0.0f, 0.0f));
+}
+
+TEST_F(Polygon2DTest, ContainmentAndAdjacency)
+{
+	spk::Polygon2D outer =
+		spk::Polygon2D::makeSquare(spk::Vector2(0.0f, 0.0f), spk::Vector2(2.0f, 0.0f), spk::Vector2(2.0f, 2.0f), spk::Vector2(0.0f, 2.0f));
+	spk::Polygon2D inner =
+		spk::Polygon2D::makeSquare(spk::Vector2(0.5f, 0.5f), spk::Vector2(1.5f, 0.5f), spk::Vector2(1.5f, 1.5f), spk::Vector2(0.5f, 1.5f));
+	spk::Polygon2D neighbor =
+		spk::Polygon2D::makeSquare(spk::Vector2(2.0f, 0.0f), spk::Vector2(4.0f, 0.0f), spk::Vector2(4.0f, 2.0f), spk::Vector2(2.0f, 2.0f));
+
+	EXPECT_TRUE(outer.contains(spk::Vector2(1.0f, 1.0f)));
+	EXPECT_FALSE(outer.contains(spk::Vector2(-0.1f, 1.0f)));
+	EXPECT_TRUE(outer.contains(inner));
+	EXPECT_TRUE(outer.isAdjacent(neighbor));
+	EXPECT_TRUE(outer.isConvex());
+}
+
+TEST_F(Polygon2DTest, OverlapSequantAndTriangulate)
+{
+	spk::Polygon2D concave = spk::Polygon2D::fromLoop({
+		spk::Vector2(0.0f, 0.0f),
+		spk::Vector2(2.0f, 0.0f),
+		spk::Vector2(2.0f, 1.0f),
+		spk::Vector2(1.0f, 1.0f),
+		spk::Vector2(1.0f, 2.0f),
+		spk::Vector2(0.0f, 2.0f),
+	});
+	spk::Polygon2D other =
+		spk::Polygon2D::makeSquare(spk::Vector2(1.0f, 0.5f), spk::Vector2(2.5f, 0.5f), spk::Vector2(2.5f, 1.5f), spk::Vector2(1.0f, 1.5f));
+
+	EXPECT_FALSE(concave.isConvex());
+	EXPECT_TRUE(concave.isOverlapping(other));
+	EXPECT_TRUE(concave.isSequant(other));
+
+	std::vector<spk::Polygon2D> triangles = concave.triangulate();
+	float totalArea =
+		std::accumulate(triangles.begin(), triangles.end(), 0.0f, [](float p_acc, const spk::Polygon2D &p_tri) { return p_acc + p_tri.area(); });
+	EXPECT_NEAR(totalArea, concave.area(), 1e-4f);
+
+	std::vector<spk::Polygon2D> convexParts = concave.splitIntoConvex();
+	EXPECT_GE(convexParts.size(), 2U);
+	for (const auto &poly : convexParts)
+	{
+		EXPECT_TRUE(poly.isConvex());
+	}
+}

--- a/checker/src/structure/math/spk_polygon_fuze_tester.cpp
+++ b/checker/src/structure/math/spk_polygon_fuze_tester.cpp
@@ -1,0 +1,41 @@
+#include "structure/math/spk_polygon_fuze_tester.hpp"
+
+TEST_F(PolygonFuzeTest, FuzeAdjacentSquares)
+{
+	spk::Polygon left = spk::Polygon::makeSquare(
+		spk::Vector3(-1.0f, -1.0f, 0.0f), spk::Vector3(0.0f, -1.0f, 0.0f), spk::Vector3(0.0f, 1.0f, 0.0f), spk::Vector3(-1.0f, 1.0f, 0.0f));
+	spk::Polygon right = spk::Polygon::makeSquare(
+		spk::Vector3(0.0f, -1.0f, 0.0f), spk::Vector3(1.0f, -1.0f, 0.0f), spk::Vector3(1.0f, 1.0f, 0.0f), spk::Vector3(0.0f, 1.0f, 0.0f));
+
+	spk::Polygon fused = left.fuze(right, true);
+	EXPECT_TRUE(fused.contains(spk::Vector3(-0.5f, 0.0f, 0.0f)));
+	EXPECT_TRUE(fused.contains(spk::Vector3(0.5f, 0.0f, 0.0f)));
+	EXPECT_FALSE(fused.contains(spk::Vector3(1.5f, 0.0f, 0.0f)));
+	EXPECT_TRUE(fused.isConvex());
+}
+
+TEST_F(PolygonFuzeTest, FuzeGroupCombinesAll)
+{
+	spk::Polygon a = spk::Polygon::makeSquare(
+		spk::Vector3(0.0f, 0.0f, 0.0f), spk::Vector3(1.0f, 0.0f, 0.0f), spk::Vector3(1.0f, 1.0f, 0.0f), spk::Vector3(0.0f, 1.0f, 0.0f));
+	spk::Polygon b = spk::Polygon::makeSquare(
+		spk::Vector3(1.0f, 0.0f, 0.0f), spk::Vector3(2.0f, 0.0f, 0.0f), spk::Vector3(2.0f, 1.0f, 0.0f), spk::Vector3(1.0f, 1.0f, 0.0f));
+	spk::Polygon c = spk::Polygon::makeSquare(
+		spk::Vector3(0.0f, 1.0f, 0.0f), spk::Vector3(1.0f, 1.0f, 0.0f), spk::Vector3(1.0f, 2.0f, 0.0f), spk::Vector3(0.0f, 2.0f, 0.0f));
+
+	spk::Polygon fused = spk::Polygon::fuzeGroup({a, b, c});
+	EXPECT_TRUE(fused.contains(spk::Vector3(0.5f, 0.5f, 0.0f)));
+	EXPECT_TRUE(fused.contains(spk::Vector3(1.5f, 0.5f, 0.0f)));
+	EXPECT_TRUE(fused.contains(spk::Vector3(0.5f, 1.5f, 0.0f)));
+	EXPECT_FALSE(fused.contains(spk::Vector3(1.5f, 1.5f, 0.0f)));
+}
+
+TEST_F(PolygonFuzeTest, NonCoplanarCheckRaises)
+{
+	spk::Polygon base = spk::Polygon::makeSquare(
+		spk::Vector3(0.0f, 0.0f, 0.0f), spk::Vector3(1.0f, 0.0f, 0.0f), spk::Vector3(1.0f, 1.0f, 0.0f), spk::Vector3(0.0f, 1.0f, 0.0f));
+	spk::Polygon tilted = spk::Polygon::makeSquare(
+		spk::Vector3(0.0f, 0.0f, 1.0f), spk::Vector3(1.0f, 0.0f, 1.0f), spk::Vector3(1.0f, 1.0f, 1.0f), spk::Vector3(0.0f, 1.0f, 1.0f));
+
+	EXPECT_THROW(base.fuze(tilted, true), std::runtime_error);
+}

--- a/checker/src/structure/math/spk_quaternion_tester.cpp
+++ b/checker/src/structure/math/spk_quaternion_tester.cpp
@@ -1,0 +1,54 @@
+#include "structure/math/spk_quaternion_tester.hpp"
+
+#include <cmath>
+
+TEST_F(QuaternionTest, EulerRoundTrip)
+{
+	spk::Vector3 euler(45.0f, -60.0f, 30.0f);
+	spk::Quaternion q = spk::Quaternion::fromEuler(euler);
+	spk::Vector3 restored = q.toEuler();
+
+	EXPECT_NEAR(restored.x, euler.x, 1e-3f);
+	EXPECT_NEAR(restored.y, euler.y, 1e-3f);
+	EXPECT_NEAR(restored.z, euler.z, 1e-3f);
+}
+
+TEST_F(QuaternionTest, AxisAngleRotation)
+{
+	spk::Quaternion rot = spk::Quaternion::fromAxisAngle(spk::Vector3(0.0f, 0.0f, 1.0f), 90.0f);
+	spk::Vector3 rotated = rot.rotate(spk::Vector3(1.0f, 0.0f, 0.0f));
+
+	EXPECT_NEAR(rotated.x, 0.0f, 1e-4f);
+	EXPECT_NEAR(rotated.y, 1.0f, 1e-4f);
+	EXPECT_NEAR(rotated.z, 0.0f, 1e-4f);
+}
+
+TEST_F(QuaternionTest, LookAtMatchesForward)
+{
+	spk::Vector3 eye(0.0f, 0.0f, 0.0f);
+	spk::Vector3 target(1.0f, 1.0f, 0.0f);
+	spk::Vector3 up(0.0f, 1.0f, 0.0f);
+
+	spk::Quaternion look = spk::Quaternion::lookAt(eye, target, up);
+	spk::Vector3 rotated = look.rotate(spk::Vector3(0.0f, 0.0f, -1.0f)).normalize();
+	spk::Vector3 forward = (target - eye).normalize();
+
+	EXPECT_NEAR(rotated.x, forward.x, 1e-4f);
+	EXPECT_NEAR(rotated.y, forward.y, 1e-4f);
+	EXPECT_NEAR(rotated.z, forward.z, 1e-4f);
+}
+
+TEST_F(QuaternionTest, LookAtHandlesParallelUp)
+{
+	spk::Vector3 eye(0.0f, 0.0f, 0.0f);
+	spk::Vector3 target(0.0f, 1.0f, 0.0f);
+	spk::Vector3 up(0.0f, 1.0f, 0.0f);
+
+	spk::Quaternion look = spk::Quaternion::lookAt(eye, target, up);
+	spk::Vector3 rotated = look.rotate(spk::Vector3(0.0f, 0.0f, -1.0f)).normalize();
+	spk::Vector3 forward = (target - eye).normalize();
+
+	EXPECT_NEAR(rotated.x, forward.x, 1e-4f);
+	EXPECT_NEAR(rotated.y, forward.y, 1e-4f);
+	EXPECT_NEAR(rotated.z, forward.z, 1e-4f);
+}

--- a/checker/src/structure/math/spk_vector2_tester.cpp
+++ b/checker/src/structure/math/spk_vector2_tester.cpp
@@ -110,7 +110,8 @@ TEST_F(Vector2Test, EqualityOperator)
 	spk::IVector2<float> vecFloat4(3.5f, 4.0f);
 
 	EXPECT_TRUE(vecInt4 == vecFloat4) << "Upon casting float to int, vecFloat should be equal as 3.5 should be concidered as 3";
-	EXPECT_FALSE(vecFloat4 == vecInt4) << "Upon casting int to float, vecInt should be equal as 3 should be concidered as 3.0 and therefor must be different";
+	EXPECT_FALSE(vecFloat4 == vecInt4)
+		<< "Upon casting int to float, vecInt should be equal as 3 should be concidered as 3.0 and therefor must be different";
 }
 
 TEST_F(Vector2Test, MixedTypeEqualityOperator)
@@ -170,7 +171,7 @@ TEST_F(Vector2Test, ComparatorOperators)
 	EXPECT_FALSE(value <= xEqualYLower) << "Comparing with X Equal and Y Bigger with operator <= should return true";
 	EXPECT_TRUE(value <= xBiggerYEqual) << "Comparing with X Equal and Y Bigger with operator <= should return false";
 	EXPECT_FALSE(value <= xLowerYEqual) << "Comparing with X Equal and Y Bigger with operator <= should return true";
-	
+
 	EXPECT_TRUE(value >= xEqualYEqual) << "Comparing with X Equal and Y Bigger with operator >= should return false";
 	EXPECT_FALSE(value >= xEqualYBigger) << "Comparing with X Equal and Y Bigger with operator >= should return false";
 	EXPECT_TRUE(value >= xEqualYLower) << "Comparing with X Equal and Y Bigger with operator >= should return true";
@@ -186,8 +187,10 @@ TEST_F(Vector2Test, ToStringMethod)
 	EXPECT_EQ(spk::IVector2<size_t>(3, 4).toString(), "(3, 4)") << "to_string method should return correct string representation for size_t";
 
 	EXPECT_EQ(spk::IVector2<int>(3, -4).toWstring(), L"(3, -4)") << "to_string method should return correct string representation for int";
-	EXPECT_EQ(spk::IVector2<float>(3.5f, 4.5f).toWstring(), L"(3.5, 4.5)") << "to_string method should return correct string representation for float";
-	EXPECT_EQ(spk::IVector2<double>(3.5, 4.5).toWstring(), L"(3.5, 4.5)") << "to_string method should return correct string representation for double";
+	EXPECT_EQ(spk::IVector2<float>(3.5f, 4.5f).toWstring(), L"(3.5, 4.5)")
+		<< "to_string method should return correct string representation for float";
+	EXPECT_EQ(spk::IVector2<double>(3.5, 4.5).toWstring(), L"(3.5, 4.5)")
+		<< "to_string method should return correct string representation for double";
 	EXPECT_EQ(spk::IVector2<size_t>(3, 4).toWstring(), L"(3, 4)") << "to_string method should return correct string representation for size_t";
 }
 
@@ -328,56 +331,45 @@ TEST_F(Vector2Test, DivisionByZero)
 	spk::IVector2<int> vecInt(3, 4);
 	int zeroInt = 0;
 
-	EXPECT_THROW(
-		{
-			spk::IVector2<int> result = vecInt / zeroInt;
-		}, std::runtime_error) << "Division by zero for int should throw runtime_error";
+	EXPECT_THROW({ spk::IVector2<int> result = vecInt / zeroInt; }, std::runtime_error) << "Division by zero for int should throw runtime_error";
 
-	EXPECT_THROW(
-		{
-			vecInt /= zeroInt;
-		}, std::runtime_error) << "Division assignment by zero for int should throw runtime_error";
+	EXPECT_THROW({ vecInt /= zeroInt; }, std::runtime_error) << "Division assignment by zero for int should throw runtime_error";
 
 	spk::IVector2<float> vecFloat(3.0f, 4.0f);
 	float zeroFloat = 0.0f;
 
 	EXPECT_THROW(
-		{
-			spk::IVector2<float> result = vecFloat / zeroFloat;
-		}, std::runtime_error) << "Division by zero for float should throw runtime_error";
+		{ spk::IVector2<float> result = vecFloat / zeroFloat; }, std::runtime_error)
+		<< "Division by zero for float should throw runtime_error";
 
-	EXPECT_THROW(
-		{
-			vecFloat /= zeroFloat;
-		}, std::runtime_error) << "Division assignment by zero for float should throw runtime_error";
+	EXPECT_THROW({ vecFloat /= zeroFloat; }, std::runtime_error) << "Division assignment by zero for float should throw runtime_error";
 
 	spk::IVector2<double> vecDouble(3.0, 4.0);
 	double zeroDouble = 0.0;
 
 	EXPECT_THROW(
-		{
-			spk::IVector2<double> result = vecDouble / zeroDouble;
-		}, std::runtime_error) << "Division by zero for double should throw runtime_error";
+		{ spk::IVector2<double> result = vecDouble / zeroDouble; }, std::runtime_error)
+		<< "Division by zero for double should throw runtime_error";
 
-	EXPECT_THROW(
-		{
-			vecDouble /= zeroDouble;
-		}, std::runtime_error) << "Division assignment by zero for double should throw runtime_error";
+	EXPECT_THROW({ vecDouble /= zeroDouble; }, std::runtime_error) << "Division assignment by zero for double should throw runtime_error";
 }
 
 TEST_F(Vector2Test, DistanceMethod)
 {
 	spk::IVector2<int> vec1(1, 2);
 	spk::IVector2<int> vec2(4, 5);
-	EXPECT_FLOAT_EQ(vec1.distance(vec2), static_cast<float>(std::sqrt(18))) << "Distance method should return the correct distance between two vectors";
+	EXPECT_FLOAT_EQ(vec1.distance(vec2), static_cast<float>(std::sqrt(18)))
+		<< "Distance method should return the correct distance between two vectors";
 
 	spk::IVector2<float> vecFloat1(1.0f, 2.0f);
 	spk::IVector2<float> vecFloat2(4.0f, 5.0f);
-	EXPECT_FLOAT_EQ(vecFloat1.distance(vecFloat2), static_cast<float>(std::sqrt(18.0f))) << "Distance method should return the correct distance between two float vectors";
+	EXPECT_FLOAT_EQ(vecFloat1.distance(vecFloat2), static_cast<float>(std::sqrt(18.0f)))
+		<< "Distance method should return the correct distance between two float vectors";
 
 	spk::IVector2<double> vecDouble1(1.0, 2.0);
 	spk::IVector2<double> vecDouble2(4.0, 5.0);
-	EXPECT_FLOAT_EQ(vecDouble1.distance(vecDouble2), static_cast<float>(std::sqrt(18.0))) << "Distance method should return the correct distance between two double vectors";
+	EXPECT_FLOAT_EQ(vecDouble1.distance(vecDouble2), static_cast<float>(std::sqrt(18.0)))
+		<< "Distance method should return the correct distance between two double vectors";
 }
 
 TEST_F(Vector2Test, NormMethod)
@@ -544,4 +536,64 @@ TEST_F(Vector2Test, LerpMethod)
 	spk::IVector2<int> end(10, 10);
 	auto lerpVec = spk::IVector2<int>::lerp(start, end, 0.5f);
 	EXPECT_EQ(lerpVec, spk::IVector2<int>(5, 5)) << "Lerp method should return the correct linearly interpolated vector";
+}
+
+TEST_F(Vector2Test, PositiveModuloMethod)
+{
+	spk::IVector2<int> value(-3, 14);
+	spk::IVector2<int> modulo(10, 5);
+
+	auto wrapped = value.positiveModulo(modulo);
+
+	EXPECT_EQ(wrapped, spk::IVector2<int>(7, 4)) << "Positive modulo should wrap each component independently";
+
+	value = spk::IVector2<int>(-25, -1);
+	modulo = spk::IVector2<int>(7, 3);
+
+	wrapped = value.positiveModulo(modulo);
+
+	EXPECT_EQ(wrapped, spk::IVector2<int>(3, 2)) << "Positive modulo should always return positive components";
+}
+
+TEST_F(Vector2Test, IsBetweenMethod)
+{
+	spk::IVector2<int> lower(0, 0);
+	spk::IVector2<int> upper(10, 10);
+
+	EXPECT_TRUE(spk::IVector2<int>(5, 5).isBetween(lower, upper)) << "Vector inside the range should return true";
+	EXPECT_TRUE(spk::IVector2<int>(0, 10).isBetween(lower, upper)) << "Boundary values should be considered inside";
+	EXPECT_FALSE(spk::IVector2<int>(-1, 5).isBetween(lower, upper)) << "Values lower than the range should return false";
+	EXPECT_FALSE(spk::IVector2<int>(5, 11).isBetween(lower, upper)) << "Values higher than the range should return false";
+}
+
+TEST_F(Vector2Test, JsonRoundTrip)
+{
+	spk::IVector2<int> intVec(3, -4);
+	spk::JSON::Object json = intVec.toJSON();
+
+	EXPECT_TRUE(json.contains(L"X"));
+	EXPECT_TRUE(json.contains(L"Y"));
+	EXPECT_EQ(json[L"X"].as<long>(), 3);
+	EXPECT_EQ(json[L"Y"].as<long>(), -4);
+
+	spk::IVector2<int> fromObject(json);
+	EXPECT_EQ(fromObject, intVec) << "Vector constructed from JSON object should match original";
+
+	spk::JSON::Object jsonArray(L"ArrayVec");
+	jsonArray.setAsArray();
+	jsonArray.append() = 8;
+	jsonArray.append() = -2;
+
+	spk::IVector2<int> fromArray(jsonArray);
+	EXPECT_EQ(fromArray, spk::IVector2<int>(8, -2)) << "Vector constructed from JSON array should read values in order";
+
+	spk::JSON::Object floatObject(L"FloatVec");
+	floatObject.addAttribute(L"X") = 1.25;
+	floatObject.addAttribute(L"Y") = -2.5;
+
+	spk::IVector2<float> floatVec;
+	floatVec.fromJSON(floatObject);
+
+	EXPECT_FLOAT_EQ(floatVec.x, 1.25f);
+	EXPECT_FLOAT_EQ(floatVec.y, -2.5f);
 }

--- a/checker/src/structure/math/spk_vector3_tester.cpp
+++ b/checker/src/structure/math/spk_vector3_tester.cpp
@@ -145,7 +145,8 @@ TEST_F(Vector3Test, EqualityOperator)
 	spk::IVector3<float> vecFloat4(3.5f, 4.0f, 5.0f);
 
 	EXPECT_TRUE(vecInt4 == vecFloat4) << "Upon casting float to int, vecFloat should be equal as 3.5 should be concidered as 3";
-	EXPECT_FALSE(vecFloat4 == vecInt4) << "Upon casting int to float, vecInt should be equal as 3 should be concidered as 3.0 and therefor must be different";
+	EXPECT_FALSE(vecFloat4 == vecInt4)
+		<< "Upon casting int to float, vecInt should be equal as 3 should be concidered as 3.0 and therefor must be different";
 }
 
 TEST_F(Vector3Test, MixedTypeEqualityOperator)
@@ -226,13 +227,17 @@ TEST_F(Vector3Test, ComparatorOperators)
 TEST_F(Vector3Test, ToStringMethod)
 {
 	EXPECT_EQ(spk::IVector3<int>(3, -4, 5).toString(), "(3, -4, 5)") << "to_string method should return correct string representation for int";
-	EXPECT_EQ(spk::IVector3<float>(3.5f, 4.5f, 5.5f).toString(), "(3.5, 4.5, 5.5)") << "to_string method should return correct string representation for float";
-	EXPECT_EQ(spk::IVector3<double>(3.5, 4.5, 5.5).toString(), "(3.5, 4.5, 5.5)") << "to_string method should return correct string representation for double";
+	EXPECT_EQ(spk::IVector3<float>(3.5f, 4.5f, 5.5f).toString(), "(3.5, 4.5, 5.5)")
+		<< "to_string method should return correct string representation for float";
+	EXPECT_EQ(spk::IVector3<double>(3.5, 4.5, 5.5).toString(), "(3.5, 4.5, 5.5)")
+		<< "to_string method should return correct string representation for double";
 	EXPECT_EQ(spk::IVector3<size_t>(3, 4, 5).toString(), "(3, 4, 5)") << "to_string method should return correct string representation for size_t";
 
 	EXPECT_EQ(spk::IVector3<int>(3, -4, 5).toWstring(), L"(3, -4, 5)") << "to_string method should return correct string representation for int";
-	EXPECT_EQ(spk::IVector3<float>(3.5f, 4.5f, 5.5f).toWstring(), L"(3.5, 4.5, 5.5)") << "to_string method should return correct string representation for float";
-	EXPECT_EQ(spk::IVector3<double>(3.5, 4.5, 5.5).toWstring(), L"(3.5, 4.5, 5.5)") << "to_string method should return correct string representation for double";
+	EXPECT_EQ(spk::IVector3<float>(3.5f, 4.5f, 5.5f).toWstring(), L"(3.5, 4.5, 5.5)")
+		<< "to_string method should return correct string representation for float";
+	EXPECT_EQ(spk::IVector3<double>(3.5, 4.5, 5.5).toWstring(), L"(3.5, 4.5, 5.5)")
+		<< "to_string method should return correct string representation for double";
 	EXPECT_EQ(spk::IVector3<size_t>(3, 4, 5).toWstring(), L"(3, 4, 5)") << "to_string method should return correct string representation for size_t";
 }
 
@@ -362,7 +367,8 @@ TEST_F(Vector3Test, CompoundAssignmentOperatorsWithScalar)
 	EXPECT_EQ(vecFloat, spk::IVector3<float>(3.0f, 4.0f, 5.0f)) << "Compound subtraction operator with scalar should subtract correctly for float";
 
 	vecFloat *= scalarFloat;
-	EXPECT_EQ(vecFloat, spk::IVector3<float>(6.0f, 8.0f, 10.0f)) << "Compound multiplication operator with scalar should multiply correctly for float";
+	EXPECT_EQ(vecFloat, spk::IVector3<float>(6.0f, 8.0f, 10.0f))
+		<< "Compound multiplication operator with scalar should multiply correctly for float";
 
 	vecFloat /= scalarFloat;
 	EXPECT_EQ(vecFloat, spk::IVector3<float>(3.0f, 4.0f, 5.0f)) << "Compound division operator with scalar should divide correctly for float";
@@ -373,56 +379,45 @@ TEST_F(Vector3Test, DivisionByZero)
 	spk::IVector3<int> vecInt(3, 4, 5);
 	int zeroInt = 0;
 
-	EXPECT_THROW(
-		{
-			spk::IVector3<int> result = vecInt / zeroInt;
-		}, std::runtime_error) << "Division by zero for int should throw runtime_error";
+	EXPECT_THROW({ spk::IVector3<int> result = vecInt / zeroInt; }, std::runtime_error) << "Division by zero for int should throw runtime_error";
 
-	EXPECT_THROW(
-		{
-			vecInt /= zeroInt;
-		}, std::runtime_error) << "Division assignment by zero for int should throw runtime_error";
+	EXPECT_THROW({ vecInt /= zeroInt; }, std::runtime_error) << "Division assignment by zero for int should throw runtime_error";
 
 	spk::IVector3<float> vecFloat(3.0f, 4.0f, 5.0f);
 	float zeroFloat = 0.0f;
 
 	EXPECT_THROW(
-		{
-			spk::IVector3<float> result = vecFloat / zeroFloat;
-		}, std::runtime_error) << "Division by zero for float should throw runtime_error";
+		{ spk::IVector3<float> result = vecFloat / zeroFloat; }, std::runtime_error)
+		<< "Division by zero for float should throw runtime_error";
 
-	EXPECT_THROW(
-		{
-			vecFloat /= zeroFloat;
-		}, std::runtime_error) << "Division assignment by zero for float should throw runtime_error";
+	EXPECT_THROW({ vecFloat /= zeroFloat; }, std::runtime_error) << "Division assignment by zero for float should throw runtime_error";
 
 	spk::IVector3<double> vecDouble(3.0, 4.0, 5.0);
 	double zeroDouble = 0.0;
 
 	EXPECT_THROW(
-		{
-			spk::IVector3<double> result = vecDouble / zeroDouble;
-		}, std::runtime_error) << "Division by zero for double should throw runtime_error";
+		{ spk::IVector3<double> result = vecDouble / zeroDouble; }, std::runtime_error)
+		<< "Division by zero for double should throw runtime_error";
 
-	EXPECT_THROW(
-		{
-			vecDouble /= zeroDouble;
-		}, std::runtime_error) << "Division assignment by zero for double should throw runtime_error";
+	EXPECT_THROW({ vecDouble /= zeroDouble; }, std::runtime_error) << "Division assignment by zero for double should throw runtime_error";
 }
 
 TEST_F(Vector3Test, DistanceMethod)
 {
 	spk::IVector3<int> vec1(1, 2, 3);
 	spk::IVector3<int> vec2(4, 5, 6);
-	EXPECT_FLOAT_EQ(vec1.distance(vec2), static_cast<float>(std::sqrt(27))) << "Distance method should return the correct distance between two vectors";
+	EXPECT_FLOAT_EQ(vec1.distance(vec2), static_cast<float>(std::sqrt(27)))
+		<< "Distance method should return the correct distance between two vectors";
 
 	spk::IVector3<float> vecFloat1(1.0f, 2.0f, 3.0f);
 	spk::IVector3<float> vecFloat2(4.0f, 5.0f, 6.0f);
-	EXPECT_FLOAT_EQ(vecFloat1.distance(vecFloat2), static_cast<float>(std::sqrt(27.0f))) << "Distance method should return the correct distance between two float vectors";
+	EXPECT_FLOAT_EQ(vecFloat1.distance(vecFloat2), static_cast<float>(std::sqrt(27.0f)))
+		<< "Distance method should return the correct distance between two float vectors";
 
 	spk::IVector3<double> vecDouble1(1.0, 2.0, 3.0);
 	spk::IVector3<double> vecDouble2(4.0, 5.0, 6.0);
-	EXPECT_FLOAT_EQ(vecDouble1.distance(vecDouble2), static_cast<float>(std::sqrt(27.0))) << "Distance method should return the correct distance between two double vectors";
+	EXPECT_FLOAT_EQ(vecDouble1.distance(vecDouble2), static_cast<float>(std::sqrt(27.0)))
+		<< "Distance method should return the correct distance between two double vectors";
 }
 
 TEST_F(Vector3Test, NormMethod)
@@ -624,4 +619,58 @@ TEST_F(Vector3Test, LerpMethod)
 	spk::IVector3<int> end(10, 10, 10);
 	auto lerpVec = spk::IVector3<int>::lerp(start, end, 0.5f);
 	EXPECT_EQ(lerpVec, spk::IVector3<int>(5, 5, 5)) << "Lerp method should return the correct linearly interpolated vector";
+}
+
+TEST_F(Vector3Test, PositiveModuloMethod)
+{
+	spk::IVector3<int> value(-3, 14, -22);
+	spk::IVector3<int> modulo(10, 5, 6);
+
+	auto wrapped = value.positiveModulo(modulo);
+
+	EXPECT_EQ(wrapped, spk::IVector3<int>(7, 4, 2)) << "Positive modulo should wrap each component independently";
+
+	value = spk::IVector3<int>(-31, -1, 0);
+	modulo = spk::IVector3<int>(7, 3, 4);
+
+	wrapped = value.positiveModulo(modulo);
+
+	EXPECT_EQ(wrapped, spk::IVector3<int>(3, 2, 0)) << "Positive modulo should always return non-negative components";
+}
+
+TEST_F(Vector3Test, JsonRoundTrip)
+{
+	spk::IVector3<int> intVec(3, -4, 7);
+	spk::JSON::Object json = intVec.toJSON();
+
+	EXPECT_TRUE(json.contains(L"X"));
+	EXPECT_TRUE(json.contains(L"Y"));
+	EXPECT_TRUE(json.contains(L"Z"));
+	EXPECT_EQ(json[L"X"].as<long>(), 3);
+	EXPECT_EQ(json[L"Y"].as<long>(), -4);
+	EXPECT_EQ(json[L"Z"].as<long>(), 7);
+
+	spk::IVector3<int> fromObject(json);
+	EXPECT_EQ(fromObject, intVec) << "Vector constructed from JSON object should match original";
+
+	spk::JSON::Object jsonArray(L"ArrayVec");
+	jsonArray.setAsArray();
+	jsonArray.append() = -2;
+	jsonArray.append() = 5;
+	jsonArray.append() = 9;
+
+	spk::IVector3<int> fromArray(jsonArray);
+	EXPECT_EQ(fromArray, spk::IVector3<int>(-2, 5, 9)) << "Vector constructed from JSON array should read values in order";
+
+	spk::JSON::Object floatObject(L"FloatVec");
+	floatObject.addAttribute(L"X") = 1.25;
+	floatObject.addAttribute(L"Y") = -2.5;
+	floatObject.addAttribute(L"Z") = 3.75;
+
+	spk::IVector3<float> floatVec;
+	floatVec.fromJSON(floatObject);
+
+	EXPECT_FLOAT_EQ(floatVec.x, 1.25f);
+	EXPECT_FLOAT_EQ(floatVec.y, -2.5f);
+	EXPECT_FLOAT_EQ(floatVec.z, 3.75f);
 }


### PR DESCRIPTION
## Summary
- add dedicated Edge and Edge2D unit suites covering construction, orientation, containment, and relation semantics
- validate EdgeMap/EdgeMap2D reconstruction alongside plane checks and polygon2D metrics for area, triangulation, and convex splits
- exercise polygon fusion paths plus Perlin noise determinism and quaternion rotation/look-at behaviors

## Testing
- cmake --preset test-debug *(fails: missing /scripts/buildsystems/vcpkg.cmake toolchain and Ninja)*

------
https://chatgpt.com/codex/tasks/task_e_68d5442dc2288325a799b0c34d89f8f8